### PR TITLE
feat(track/2): update module sources for Mimir components

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,6 +6,13 @@ This is a Terraform module facilitating the deployment of Mimir solution, using 
 > `s3-integrator` itself doesn't act as an S3 object storage system. For the HA solution to be functional, `s3-integrator` needs to point to an S3-like storage. See [this guide](https://discourse.charmhub.io/t/cos-lite-docs-set-up-minio/15211) to learn how to connect to an S3-like storage for traces.
 
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_juju"></a> [juju](#requirement\_juju) | ~> 1.0 |
+
 ## Providers
 
 | Name | Version |
@@ -16,10 +23,10 @@ This is a Terraform module facilitating the deployment of Mimir solution, using 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mimir_backend"></a> [mimir\_backend](#module\_mimir\_backend) | git::https://github.com/canonical/mimir-worker-k8s-operator//terraform | track/2 |
-| <a name="module_mimir_coordinator"></a> [mimir\_coordinator](#module\_mimir\_coordinator) | git::https://github.com/canonical/mimir-coordinator-k8s-operator//terraform | track/2 |
-| <a name="module_mimir_read"></a> [mimir\_read](#module\_mimir\_read) | git::https://github.com/canonical/mimir-worker-k8s-operator//terraform | track/2 |
-| <a name="module_mimir_write"></a> [mimir\_write](#module\_mimir\_write) | git::https://github.com/canonical/mimir-worker-k8s-operator//terraform | track/2 |
+| <a name="module_mimir_backend"></a> [mimir\_backend](#module\_mimir\_backend) | git::https://github.com/canonical/mimir-operators//worker/terraform | track/2 |
+| <a name="module_mimir_coordinator"></a> [mimir\_coordinator](#module\_mimir\_coordinator) | git::https://github.com/canonical/mimir-operators//coordinator/terraform | track/2 |
+| <a name="module_mimir_read"></a> [mimir\_read](#module\_mimir\_read) | git::https://github.com/canonical/mimir-operators//worker/terraform | track/2 |
+| <a name="module_mimir_write"></a> [mimir\_write](#module\_mimir\_write) | git::https://github.com/canonical/mimir-operators//worker/terraform | track/2 |
 
 ## Inputs
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -38,7 +38,7 @@ resource "juju_application" "s3_integrator" {
 }
 
 module "mimir_coordinator" {
-  source             = "git::https://github.com/canonical/mimir-coordinator-k8s-operator//terraform?ref=track/2"
+  source             = "git::https://github.com/canonical/mimir-operators//coordinator/terraform?ref=track/2"
   app_name           = "mimir"
   channel            = var.channel
   config             = var.coordinator_config
@@ -50,7 +50,7 @@ module "mimir_coordinator" {
 }
 
 module "mimir_backend" {
-  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform?ref=track/2"
+  source     = "git::https://github.com/canonical/mimir-operators//worker/terraform?ref=track/2"
   depends_on = [module.mimir_coordinator]
 
   app_name    = var.backend_name
@@ -66,7 +66,7 @@ module "mimir_backend" {
 }
 
 module "mimir_read" {
-  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform?ref=track/2"
+  source     = "git::https://github.com/canonical/mimir-operators//worker/terraform?ref=track/2"
   depends_on = [module.mimir_coordinator]
 
   app_name = var.read_name
@@ -82,7 +82,7 @@ module "mimir_read" {
 }
 
 module "mimir_write" {
-  source     = "git::https://github.com/canonical/mimir-worker-k8s-operator//terraform?ref=track/2"
+  source     = "git::https://github.com/canonical/mimir-operators//worker/terraform?ref=track/2"
   depends_on = [module.mimir_coordinator]
 
   app_name = var.write_name


### PR DESCRIPTION
Closes #8 

## Testing
```hcl
module "mimir" {
  source            = "git::https://github.com/canonical/mimir-operators//terraform?ref=lucabello-patch-2"
  model_uuid        = juju_model.monorepo.uuid
  channel           = "2/stable"
  s3_endpoint       = "http://${data.external.juju_nori_address.result.address}:8333" # Seaweed
  s3_secret_key     = "placeholder"
  s3_access_key     = "placeholder"
  coordinator_units = 1
  backend_units     = 1
  read_units        = 1
  write_units       = 1
}
```
```
terraform apply
Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
```