### PR TITLE
fix: coordinator and worker patterns causing flaky tests

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -37,6 +37,7 @@ from coordinated_workers.telemetry_correlation import TelemetryCorrelation
 from coordinated_workers.worker_telemetry import WorkerTelemetryProxyConfig
 from cosl import JujuTopology
 from cosl.interfaces.datasource_exchange import DatasourceDict
+from cosl.reconciler import all_events, observe_events
 from cosl.time_validation import is_valid_timespec
 from ops import ActiveStatus, BlockedStatus
 from ops.model import ModelError
@@ -64,7 +65,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         self._nginx_prometheus_exporter_container = self.unit.get_container(
             "nginx-prometheus-exporter"
         )
-        self._nginx_helper = NginxHelper(self._nginx_container)
+        self._nginx_helper = NginxHelper()
         self.ingress = IngressPerAppRequirer(
             charm=self,
             strip_prefix=True,
@@ -148,7 +149,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
             return
 
         # do this regardless of what event we are processing
-        self._reconcile()
+        observe_events(self, all_events, self._reconcile)
 
         ######################################
         # === EVENT HANDLER REGISTRATION === #
@@ -359,9 +360,10 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
             # Update the alert rules files on disk
             self._nginx_container.remove_path(RULES_DIR, recursive=True)
             rules_file_paths: List[str] = self._push_alert_rules(remote_write_alerts)
-            self._push(ALERTS_HASH_PATH, alerts_hash)
-            # Push the alert rules to the Mimir cluster (persisted in s3)
-            mimirtool_output = self._nginx_container.pebble.exec(
+            # Push the alert rules to the Mimir cluster (persisted in s3).
+            # wait_output() raises ExecError on non-zero exit, which will put
+            # the unit in error state so Juju retries the hook.
+            process = self._nginx_container.pebble.exec(
                 [
                     "mimirtool",
                     "rules",
@@ -372,10 +374,13 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
                 ],
                 encoding="utf-8",
             )
-            if mimirtool_output.stdout:
-                logger.info(f"mimirtool: {mimirtool_output.stdout.read().strip()}")
-            if mimirtool_output.stderr:
-                logger.error(f"mimirtool (err): {mimirtool_output.stderr.read().strip()}")
+            stdout, stderr = process.wait_output()
+            if stdout:
+                logger.info(f"mimirtool: {stdout.strip()}")
+            if stderr:
+                logger.warning(f"mimirtool (stderr): {stderr.strip()}")
+            # Only persist hash after successful sync so the next event retries on failure.
+            self._push(ALERTS_HASH_PATH, alerts_hash)
 
     def _update_prometheus_api(self) -> None:
         """Update all applications related to us via the prometheus-api relation."""
@@ -421,12 +426,11 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
             logger.info(f"Suspending data deletion due to invalid option set in config: {self.retention_period}. To resume data deletion, please reset value to a valid option.")
             event.add_status(BlockedStatus(f"Invalid config option (see debug-log): retention_period={self.retention_period}"))
 
-    def _reconcile(self):
+    def _reconcile(self, _=None):
         # This method contains unconditional update logic, i.e. logic that should be executed
         # regardless of the event we are processing.
         if self._nginx_container.can_connect():
             self._set_alerts()
-        self._ensure_mimirtool()
         self._update_prometheus_api()
         self._update_datasource_exchange()
         self.grafana_source.update_source(source_url=f"{self.most_external_url}/prometheus")

--- a/coordinator/src/nginx_config.py
+++ b/coordinator/src/nginx_config.py
@@ -6,13 +6,9 @@ import logging
 from typing import Dict, List
 
 from coordinated_workers.nginx import (
-    CA_CERT_PATH,
-    CERT_PATH,
-    KEY_PATH,
     NginxLocationConfig,
     NginxUpstream,
 )
-from ops import Container
 
 from mimir_config import MimirRole
 
@@ -56,28 +52,26 @@ class NginxHelper:
     _port = 8080
     _tls_port = 443
 
-    def __init__(self, container: Container):
-        self._container = container
-
     def upstreams(self) -> List[NginxUpstream]:
         """Generate the list of Nginx upstream metadata configurations."""
         return [NginxUpstream(role.value, self._port, role.value) for role in MimirRole]
 
     def server_ports_to_locations(self) -> Dict[int, List[NginxLocationConfig]]:
-        """Generate a mapping from server ports to a list of Nginx location configurations."""
-        return {
-            self._tls_port if self._tls_available else self._port: self._locations_distributor
+        """Generate a mapping from server ports to a list of Nginx location configurations.
+
+        Locations are provided for both the plain HTTP and TLS ports so that the
+        nginx server block is valid regardless of when TLS certificates become
+        available.  The Coordinator library controls which port actually receives
+        traffic via ``listen_tls`` and ``unit.set_ports``.
+        """
+        all_locations = (
+            self._locations_distributor
             + self._locations_ruler
             + self._locations_alertmanager
             + self._locations_query_frontend
             + self._locations_compactor
-        }
-
-    @property
-    def _tls_available(self) -> bool:
-        return (
-            self._container.can_connect()
-            and self._container.exists(CERT_PATH)
-            and self._container.exists(KEY_PATH)
-            and self._container.exists(CA_CERT_PATH)
         )
+        return {
+            self._port: all_locations,
+            self._tls_port: all_locations,
+        }

--- a/coordinator/tests/unit/test_nginx_config.py
+++ b/coordinator/tests/unit/test_nginx_config.py
@@ -1,5 +1,5 @@
 from contextlib import contextmanager
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from coordinated_workers.nginx import NginxConfig
@@ -17,11 +17,10 @@ def mock_ipv6(enable: bool):
 def nginx_config():
     def _nginx_config(tls=False, ipv6=True):
         with mock_ipv6(ipv6):
-            with patch.object(NginxHelper, "_tls_available", new=PropertyMock(return_value=tls)):
-                nginx_helper = NginxHelper(MagicMock())
-                return NginxConfig(server_name="localhost",
-                                    upstream_configs=nginx_helper.upstreams(),
-                                    server_ports_to_locations=nginx_helper.server_ports_to_locations())
+            nginx_helper = NginxHelper()
+            return NginxConfig(server_name="localhost",
+                                upstream_configs=nginx_helper.upstreams(),
+                                server_ports_to_locations=nginx_helper.server_ports_to_locations())
     return _nginx_config
 
 
@@ -88,14 +87,26 @@ def test_upstreams_config(nginx_config, coordinator, addresses_by_role):
 @pytest.mark.parametrize("tls", (True, False))
 @pytest.mark.parametrize("ipv6", (True, False))
 def test_servers_config(ipv6, tls, nginx_config):
-    port = 8080
     server_config = nginx_config(tls=tls, ipv6=ipv6).get_config(
         {"distributor": ["address.one"]}, tls
     )
-    ipv4_args = "443 ssl" if tls else f"{port}"
-    assert f"listen {ipv4_args}" in  server_config
-    ipv6_args = "[::]:443 ssl" if tls else f"[::]:{port}"
-    if ipv6:
-        assert f"listen {ipv6_args}" in server_config
+    # Both ports (8080 and 443) always get location blocks.
+    # When tls=True, both server blocks carry the 'ssl' directive;
+    # when tls=False, neither does.
+    if tls:
+        assert "listen 443 ssl" in server_config
+        assert "listen 8080 ssl" in server_config
     else:
-        assert f"listen {ipv6_args}" not in server_config
+        assert "listen 8080" in server_config
+        assert "listen 443" in server_config
+        assert "ssl" not in server_config
+
+    if ipv6:
+        if tls:
+            assert "listen [::]:443 ssl" in server_config
+            assert "listen [::]:8080 ssl" in server_config
+        else:
+            assert "listen [::]:8080" in server_config
+            assert "listen [::]:443" in server_config
+    else:
+        assert "[::]:" not in server_config


### PR DESCRIPTION
## Problem

Integration tests are flaky — charms get stuck in non-active/idle statuses or don't converge in time. A comparative analysis with the Tempo operators (which use the same `coordinated-workers` pattern and have far more stable tests) identified several architectural differences causing this.

## Changes

### 1. Fix mimirtool alert sync bug (coordinator)

`_set_alerts()` had two bugs:
- The alerts hash was written **before** `mimirtool rules sync` ran, so if mimirtool failed, the hash was already updated and no retry would ever occur.
- `pebble.exec()` was used without calling `wait()`, so non-zero exit codes were silently swallowed.

Now uses `wait_output()` (which raises `ExecError` on failure), and writes the hash only after successful execution. On failure, the unit enters error state and Juju retries the hook — by which time workers may have settled.

Also removes the redundant `_ensure_mimirtool()` call from `_reconcile()` (it's already called inside `_set_alerts()`).

### 2. Migrate to `observe_events` pattern (coordinator)

Replaces the inline `self._reconcile()` call in `__init__` with `observe_events(self, all_events, self._reconcile)` from `cosl.reconciler`, matching the pattern used by Tempo. This registers `_reconcile` as a proper event handler through the ops framework instead of running it during charm construction.

### 3. Fix nginx TLS port race condition (coordinator)

`NginxHelper.server_ports_to_locations()` checked TLS certificate existence on disk at init time. If the container wasn't ready, TLS was never detected and port 8080 was used — even though the Coordinator later decided `listen_tls=True` and published port 443. This mismatch caused nginx to listen on the wrong port.

Now provides locations for **both** ports (8080 and 443). The Coordinator library selects the correct one at config-generation time via `listen_tls` and `unit.set_ports`. The `Container` dependency and `_tls_available` property are removed.