### PR TITLE
feat(terraform): add channel validation

### DIFF
--- a/coordinator/terraform/variables.tf
+++ b/coordinator/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,6 +6,11 @@ variable "model_uuid" {
 variable "channel" {
   description = "Channel that the applications are deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "anti_affinity" {

--- a/worker/terraform/variables.tf
+++ b/worker/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

See canonical/alertmanager-k8s-operator#403 for reference.