### PR TITLE
feat(terraform): support monolithic deployment mode

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -49,8 +49,26 @@ module "mimir_coordinator" {
   units              = var.coordinator_units
 }
 
+module "mimir_all" {
+  source     = "../worker/terraform"
+  count      = var.monolithic ? 1 : 0
+  depends_on = [module.mimir_coordinator]
+
+  app_name    = var.all_name
+  channel     = var.channel
+  constraints = var.anti_affinity ? "arch=amd64 tags=anti-pod.app.kubernetes.io/name=${var.all_name},anti-pod.topology-key=kubernetes.io/hostname" : var.worker_constraints
+  config = merge({
+    role-all = true
+  }, var.all_config)
+  model_uuid         = var.model_uuid
+  revision           = var.worker_revision
+  storage_directives = var.all_worker_storage_directives
+  units              = var.all_units
+}
+
 module "mimir_backend" {
   source     = "../worker/terraform"
+  count      = var.monolithic ? 0 : 1
   depends_on = [module.mimir_coordinator]
 
   app_name    = var.backend_name
@@ -67,6 +85,7 @@ module "mimir_backend" {
 
 module "mimir_read" {
   source     = "../worker/terraform"
+  count      = var.monolithic ? 0 : 1
   depends_on = [module.mimir_coordinator]
 
   app_name = var.read_name
@@ -83,6 +102,7 @@ module "mimir_read" {
 
 module "mimir_write" {
   source     = "../worker/terraform"
+  count      = var.monolithic ? 0 : 1
   depends_on = [module.mimir_coordinator]
 
   app_name = var.write_name
@@ -112,7 +132,8 @@ resource "juju_integration" "coordinator_to_s3_integrator" {
   }
 }
 
-resource "juju_integration" "coordinator_to_read" {
+resource "juju_integration" "coordinator_to_all" {
+  count      = var.monolithic ? 1 : 0
   model_uuid = var.model_uuid
 
   application {
@@ -121,12 +142,28 @@ resource "juju_integration" "coordinator_to_read" {
   }
 
   application {
-    name     = module.mimir_read.app_name
-    endpoint = module.mimir_read.requires.mimir_cluster
+    name     = module.mimir_all[0].app_name
+    endpoint = module.mimir_all[0].requires.mimir_cluster
+  }
+}
+
+resource "juju_integration" "coordinator_to_read" {
+  count      = var.monolithic ? 0 : 1
+  model_uuid = var.model_uuid
+
+  application {
+    name     = module.mimir_coordinator.app_name
+    endpoint = module.mimir_coordinator.provides.mimir_cluster
+  }
+
+  application {
+    name     = module.mimir_read[0].app_name
+    endpoint = module.mimir_read[0].requires.mimir_cluster
   }
 }
 
 resource "juju_integration" "coordinator_to_write" {
+  count      = var.monolithic ? 0 : 1
   model_uuid = var.model_uuid
 
   application {
@@ -135,12 +172,13 @@ resource "juju_integration" "coordinator_to_write" {
   }
 
   application {
-    name     = module.mimir_write.app_name
-    endpoint = module.mimir_write.requires.mimir_cluster
+    name     = module.mimir_write[0].app_name
+    endpoint = module.mimir_write[0].requires.mimir_cluster
   }
 }
 
 resource "juju_integration" "coordinator_to_backend" {
+  count      = var.monolithic ? 0 : 1
   model_uuid = var.model_uuid
 
   application {
@@ -149,7 +187,7 @@ resource "juju_integration" "coordinator_to_backend" {
   }
 
   application {
-    name     = module.mimir_backend.app_name
-    endpoint = module.mimir_backend.requires.mimir_cluster
+    name     = module.mimir_backend[0].app_name
+    endpoint = module.mimir_backend[0].requires.mimir_cluster
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,9 +3,10 @@ output "app_names" {
     {
       mimir_s3_integrator = juju_application.s3_integrator.name,
       mimir_coordinator   = module.mimir_coordinator.app_name,
-      mimir_read          = module.mimir_read.app_name,
-      mimir_write         = module.mimir_write.app_name,
-      mimir_backend       = module.mimir_backend.app_name,
+      mimir_read          = var.monolithic ? null : module.mimir_read[0].app_name,
+      mimir_write         = var.monolithic ? null : module.mimir_write[0].app_name,
+      mimir_backend       = var.monolithic ? null : module.mimir_backend[0].app_name,
+      mimir_all           = var.monolithic ? module.mimir_all[0].app_name : null,
     }
   )
   description = "All application names which make up this product module"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,12 @@ variable "channel" {
   }
 }
 
+variable "monolithic" {
+  description = "Deploy Mimir in monolithic mode with a single all-in-one worker instead of separate backend/read/write workers"
+  type        = bool
+  default     = false
+}
+
 variable "anti_affinity" {
   description = "Enable anti-affinity constraints."
   type        = bool
@@ -63,6 +69,12 @@ variable "write_name" {
   default     = "mimir-write"
 }
 
+variable "all_name" {
+  description = "Name of the Mimir all-in-one worker app"
+  type        = string
+  default     = "mimir-worker"
+}
+
 variable "backend_name" {
   description = "Name of the Mimir backend (meta role) app"
   type        = string
@@ -79,6 +91,12 @@ variable "s3_integrator_name" {
 
 variable "coordinator_config" {
   description = "Map of the coordinator configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "all_config" {
+  description = "Map of the all-in-one worker configuration options"
   type        = map(string)
   default     = {}
 }
@@ -177,6 +195,12 @@ variable "coordinator_storage_directives" {
   default     = {}
 }
 
+variable "all_worker_storage_directives" {
+  description = "Map of storage used by the all-in-one worker application, which defaults to 1 GB, allocated by Juju"
+  type        = map(string)
+  default     = {}
+}
+
 variable "backend_worker_storage_directives" {
   description = "Map of storage used by the backend worker application, which defaults to 1 GB, allocated by Juju"
   type        = map(string)
@@ -202,6 +226,16 @@ variable "s3_integrator_storage_directives" {
 }
 
 # -------------- # Units Per App --------------
+
+variable "all_units" {
+  description = "Number of Mimir worker units with the all-in-one role"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.all_units >= 1
+    error_message = "The number of units must be greater than or equal to 1."
+  }
+}
 
 variable "read_units" {
   description = "Number of Mimir worker units with the read meta role"


### PR DESCRIPTION
Adds a `monolithic` variable to the terraform module. When set to `true`, a single
role-all worker is deployed instead of separate backend/read/write workers.

This is needed by canonical/observability-stack#193 to support lightweight COS
deployment flavors for integration testing.

When `monolithic = false` (default), behavior is unchanged.