### PR TITLE
feat: Default s3-integrator channel to 2/stable

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -51,7 +51,7 @@ This is a Terraform module facilitating the deployment of Mimir solution, using 
 | <a name="input_s3_access_key"></a> [s3\_access\_key](#input\_s3\_access\_key) | S3 access-key credential | `string` | n/a | yes |
 | <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | Bucket name | `string` | `"mimir"` | no |
 | <a name="input_s3_endpoint"></a> [s3\_endpoint](#input\_s3\_endpoint) | S3 endpoint | `string` | n/a | yes |
-| <a name="input_s3_integrator_channel"></a> [s3\_integrator\_channel](#input\_s3\_integrator\_channel) | Channel that the s3-integrator application is deployed from | `string` | `"2/edge"` | no |
+| <a name="input_s3_integrator_channel"></a> [s3\_integrator\_channel](#input\_s3\_integrator\_channel) | Channel that the s3-integrator application is deployed from | `string` | `"2/stable"` | no |
 | <a name="input_s3_integrator_config"></a> [s3\_integrator\_config](#input\_s3\_integrator\_config) | Map of the s3-integrator configuration options | `map(string)` | `{}` | no |
 | <a name="input_s3_integrator_constraints"></a> [s3\_integrator\_constraints](#input\_s3\_integrator\_constraints) | String listing constraints for the s3-integrator application | `string` | `"arch=amd64"` | no |
 | <a name="input_s3_integrator_name"></a> [s3\_integrator\_name](#input\_s3\_integrator\_name) | Name of the s3-integrator app | `string` | `"mimir-s3-integrator"` | no |

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,7 +24,7 @@ variable "anti_affinity" {
 variable "s3_integrator_channel" {
   description = "Channel that the s3-integrator application is deployed from"
   type        = string
-  default     = "2/edge"
+  default     = "2/stable"
 }
 
 variable "s3_bucket" {


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
We want COS on the stable `risk` to reference the stable risks of all of its components.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
We used to require `2/edge` because the s3-integrator had a bucket creation feature that we wanted in COS, but now this feature has made it to 2/stable and we can remove the hardcoded edge risk.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Testing is done in here:
- https://github.com/canonical/observability-stack/pull/336
