### PR TITLE
feat: TF service mesh outputs

### DIFF
--- a/coordinator/terraform/outputs.tf
+++ b/coordinator/terraform/outputs.tf
@@ -4,12 +4,16 @@ output "app_name" {
 
 output "provides" {
   value = {
-    mimir_cluster = "mimir-cluster"
+    mimir_cluster    = "mimir-cluster",
+    provide_cmr_mesh = "provide-cmr-mesh",
   }
   description = "All Juju integration endpoints where the charm is the provider"
 }
 
 output "requires" {
-  value       = {}
+  value = {
+    require_cmr_mesh = "require-cmr-mesh",
+    service_mesh     = "service-mesh",
+  }
   description = "All Juju integration endpoints where the charm is the requirer"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -33,7 +33,7 @@ output "requires" {
     s3               = "s3",
     charm_tracing    = "charm-tracing",
     catalogue        = "catalogue",
-    require_cmr_mesh = module.mimir_coordinator.provides.require_cmr_mesh,
+    require_cmr_mesh = module.mimir_coordinator.requires.require_cmr_mesh,
     service_mesh     = module.mimir_coordinator.requires.service_mesh,
   }
   description = "All Juju integration endpoints where the charm is the requirer"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -18,6 +18,7 @@ output "provides" {
     mimir_cluster               = module.mimir_coordinator.provides.mimir_cluster,
     receive_remote_write        = "receive-remote-write",
     self_metrics_endpoint       = "self-metrics-endpoint",
+    provide_cmr_mesh            = "provide-cmr-mesh",
     send_datasource             = "send-datasource",
   }
   description = "All Juju integration endpoints where the charm is the provider"
@@ -32,6 +33,8 @@ output "requires" {
     s3               = "s3",
     charm_tracing    = "charm-tracing",
     catalogue        = "catalogue",
+    require_cmr_mesh = "require-cmr-mesh",
+    service_mesh     = "service-mesh",
   }
   description = "All Juju integration endpoints where the charm is the requirer"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -18,7 +18,7 @@ output "provides" {
     mimir_cluster               = module.mimir_coordinator.provides.mimir_cluster,
     receive_remote_write        = "receive-remote-write",
     self_metrics_endpoint       = "self-metrics-endpoint",
-    provide_cmr_mesh            = "provide-cmr-mesh",
+    provide_cmr_mesh            = module.mimir_coordinator.provides.provide_cmr_mesh,
     send_datasource             = "send-datasource",
   }
   description = "All Juju integration endpoints where the charm is the provider"
@@ -33,8 +33,8 @@ output "requires" {
     s3               = "s3",
     charm_tracing    = "charm-tracing",
     catalogue        = "catalogue",
-    require_cmr_mesh = "require-cmr-mesh",
-    service_mesh     = "service-mesh",
+    require_cmr_mesh = module.mimir_coordinator.provides.require_cmr_mesh,
+    service_mesh     = module.mimir_coordinator.provides.service_mesh,
   }
   description = "All Juju integration endpoints where the charm is the requirer"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -34,7 +34,7 @@ output "requires" {
     charm_tracing    = "charm-tracing",
     catalogue        = "catalogue",
     require_cmr_mesh = module.mimir_coordinator.provides.require_cmr_mesh,
-    service_mesh     = module.mimir_coordinator.provides.service_mesh,
+    service_mesh     = module.mimir_coordinator.requires.service_mesh,
   }
   description = "All Juju integration endpoints where the charm is the requirer"
 }


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Add TF outputs required for service mesh intergrations in products

> [!WARNING]
> We should reference the charm module requires and provides everywhere, instead of hardcoding everything. 