### PR TITLE
feat(terraform): monolithic support

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,55 +11,25 @@ module "mimir_coordinator" {
   units              = var.coordinator_units
 }
 
-module "mimir_backend" {
-  source     = "../worker/terraform"
-  depends_on = [module.mimir_coordinator]
-
-  app_name    = var.backend_name
-  channel     = var.channel
-  constraints = var.anti_affinity ? "arch=amd64 tags=anti-pod.app.kubernetes.io/name=${var.backend_name},anti-pod.topology-key=kubernetes.io/hostname" : var.worker_constraints
-  config = merge({
-    role-backend = true
-  }, var.backend_config)
-  model_uuid         = var.model_uuid
-  resources          = var.worker_resources
-  revision           = var.worker_revision
-  storage_directives = var.backend_worker_storage_directives
-  units              = var.backend_units
+locals {
+  workers = { for k, v in var.workers : k => merge(v, {
+    app_name = coalesce(v.app_name, "mimir-${k}")
+  }) }
 }
 
-module "mimir_read" {
-  source     = "../worker/terraform"
-  depends_on = [module.mimir_coordinator]
+module "mimir_worker" {
+  for_each = local.workers
+  source   = "../worker/terraform"
 
-  app_name = var.read_name
-  channel  = var.channel
-  config = merge({
-    role-read = true
-  }, var.read_config)
-  constraints        = var.anti_affinity ? "arch=amd64 tags=anti-pod.app.kubernetes.io/name=${var.read_name},anti-pod.topology-key=kubernetes.io/hostname" : var.worker_constraints
+  app_name           = each.value.app_name
+  channel            = var.channel
+  config             = merge({ "role-${each.key}" = "true" }, each.value.config)
+  constraints        = var.anti_affinity ? "arch=amd64 tags=anti-pod.app.kubernetes.io/name=${each.value.app_name},anti-pod.topology-key=kubernetes.io/hostname" : each.value.constraints
   model_uuid         = var.model_uuid
   resources          = var.worker_resources
   revision           = var.worker_revision
-  storage_directives = var.read_worker_storage_directives
-  units              = var.read_units
-}
-
-module "mimir_write" {
-  source     = "../worker/terraform"
-  depends_on = [module.mimir_coordinator]
-
-  app_name = var.write_name
-  channel  = var.channel
-  config = merge({
-    role-write = true
-  }, var.write_config)
-  constraints        = var.anti_affinity ? "arch=amd64 tags=anti-pod.app.kubernetes.io/name=${var.write_name},anti-pod.topology-key=kubernetes.io/hostname" : var.worker_constraints
-  model_uuid         = var.model_uuid
-  resources          = var.worker_resources
-  revision           = var.worker_revision
-  storage_directives = var.write_worker_storage_directives
-  units              = var.write_units
+  storage_directives = each.value.storage_directives
+  units              = each.value.units
 }
 
 # -------------- # S3-integrator --------------
@@ -117,7 +87,8 @@ resource "juju_integration" "coordinator_to_s3_integrator" {
   }
 }
 
-resource "juju_integration" "coordinator_to_read" {
+resource "juju_integration" "coordinator_to_worker" {
+  for_each   = local.workers
   model_uuid = var.model_uuid
 
   application {
@@ -126,35 +97,7 @@ resource "juju_integration" "coordinator_to_read" {
   }
 
   application {
-    name     = module.mimir_read.app_name
-    endpoint = module.mimir_read.requires.mimir_cluster
-  }
-}
-
-resource "juju_integration" "coordinator_to_write" {
-  model_uuid = var.model_uuid
-
-  application {
-    name     = module.mimir_coordinator.app_name
-    endpoint = module.mimir_coordinator.provides.mimir_cluster
-  }
-
-  application {
-    name     = module.mimir_write.app_name
-    endpoint = module.mimir_write.requires.mimir_cluster
-  }
-}
-
-resource "juju_integration" "coordinator_to_backend" {
-  model_uuid = var.model_uuid
-
-  application {
-    name     = module.mimir_coordinator.app_name
-    endpoint = module.mimir_coordinator.provides.mimir_cluster
-  }
-
-  application {
-    name     = module.mimir_backend.app_name
-    endpoint = module.mimir_backend.requires.mimir_cluster
+    name     = module.mimir_worker[each.key].app_name
+    endpoint = module.mimir_worker[each.key].requires.mimir_cluster
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,10 +3,8 @@ output "app_names" {
     {
       mimir_s3_integrator = juju_application.s3_integrator.name,
       mimir_coordinator   = module.mimir_coordinator.app_name,
-      mimir_read          = module.mimir_read.app_name,
-      mimir_write         = module.mimir_write.app_name,
-      mimir_backend       = module.mimir_backend.app_name,
-    }
+    },
+    { for k, v in module.mimir_worker : "mimir_${k}" => v.app_name }
   )
   description = "All application names which make up this product module"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,24 +49,37 @@ variable "s3_endpoint" {
   type        = string
 }
 
-# -------------- # App Names --------------
+# -------------- # Workers --------------
 
-variable "read_name" {
-  description = "Name of the Mimir read (meta role) app"
-  type        = string
-  default     = "mimir-read"
-}
+variable "workers" {
+  description = "Map of worker roles to deploy. Keys must be one of: all, backend, read, write. When 'all' is used, a single worker with role-all is created."
+  type = map(object({
+    units              = optional(number, 1)
+    config             = optional(map(string), {})
+    constraints        = optional(string, "arch=amd64")
+    storage_directives = optional(map(string), {})
+    app_name           = optional(string)
+  }))
+  default = {
+    backend = {}
+    read    = {}
+    write   = {}
+  }
 
-variable "write_name" {
-  description = "Name of the Mimir write (meta role) app"
-  type        = string
-  default     = "mimir-write"
-}
+  validation {
+    condition     = alltrue([for k in keys(var.workers) : contains(["all", "backend", "read", "write"], k)])
+    error_message = "Worker keys must be one of: all, backend, read, write."
+  }
 
-variable "backend_name" {
-  description = "Name of the Mimir backend (meta role) app"
-  type        = string
-  default     = "mimir-backend"
+  validation {
+    condition     = !(contains(keys(var.workers), "all") && length(var.workers) > 1)
+    error_message = "When using role 'all', no other worker roles may be specified."
+  }
+
+  validation {
+    condition     = alltrue([for k, v in var.workers : v.units >= 1])
+    error_message = "The number of units for each worker must be greater than or equal to 1."
+  }
 }
 
 variable "s3_integrator_name" {
@@ -79,24 +92,6 @@ variable "s3_integrator_name" {
 
 variable "coordinator_config" {
   description = "Map of the coordinator configuration options"
-  type        = map(string)
-  default     = {}
-}
-
-variable "backend_config" {
-  description = "Map of the backend worker configuration options"
-  type        = map(string)
-  default     = {}
-}
-
-variable "read_config" {
-  description = "Map of the read worker configuration options"
-  type        = map(string)
-  default     = {}
-}
-
-variable "write_config" {
-  description = "Map of the write worker configuration options"
   type        = map(string)
   default     = {}
 }
@@ -123,17 +118,6 @@ variable "coordinator_constraints" {
 
   validation {
     condition     = !(var.anti_affinity && var.coordinator_constraints != "arch=amd64")
-    error_message = "Setting both custom charm constraints and anti-affinity to true is not allowed."
-  }
-}
-
-variable "worker_constraints" {
-  description = "String listing constraints for the worker application"
-  type        = string
-  default     = "arch=amd64"
-
-  validation {
-    condition     = !(var.anti_affinity && var.worker_constraints != "arch=amd64")
     error_message = "Setting both custom charm constraints and anti-affinity to true is not allowed."
   }
 }
@@ -191,24 +175,6 @@ variable "coordinator_storage_directives" {
   default     = {}
 }
 
-variable "backend_worker_storage_directives" {
-  description = "Map of storage used by the backend worker application, which defaults to 1 GB, allocated by Juju"
-  type        = map(string)
-  default     = {}
-}
-
-variable "read_worker_storage_directives" {
-  description = "Map of storage used by the read worker application, which defaults to 1 GB, allocated by Juju"
-  type        = map(string)
-  default     = {}
-}
-
-variable "write_worker_storage_directives" {
-  description = "Map of storage used by the write worker application, which defaults to 1 GB, allocated by Juju"
-  type        = map(string)
-  default     = {}
-}
-
 variable "s3_integrator_storage_directives" {
   description = "Map of storage used by the s3-integrator application, which defaults to 1 GB, allocated by Juju"
   type        = map(string)
@@ -216,36 +182,6 @@ variable "s3_integrator_storage_directives" {
 }
 
 # -------------- # Units Per App --------------
-
-variable "read_units" {
-  description = "Number of Mimir worker units with the read meta role"
-  type        = number
-  default     = 1
-  validation {
-    condition     = var.read_units >= 1
-    error_message = "The number of units must be greater than or equal to 1."
-  }
-}
-
-variable "write_units" {
-  description = "Number of Mimir worker units with the write meta role"
-  type        = number
-  default     = 1
-  validation {
-    condition     = var.write_units >= 1
-    error_message = "The number of units must be greater than or equal to 1."
-  }
-}
-
-variable "backend_units" {
-  description = "Number of Mimir worker units with the backend meta role"
-  type        = number
-  default     = 1
-  validation {
-    condition     = var.backend_units >= 1
-    error_message = "The number of units must be greater than or equal to 1."
-  }
-}
 
 variable "coordinator_units" {
   description = "Number of Mimir coordinator units"


### PR DESCRIPTION
> [!CAUTION]
> Since we are making breaking changes:
1. API changes are not that serious because we can gate that on releases
2. `juju_application` reference changes are serious because this will replace the app. We need to either implement a `move { }` if we want the state to move. However, this is not too serious because our users use S3 storage backends anyways

## Issue
<!-- What issue is this PR trying to solve? -->
- https://github.com/canonical/observability-team/issues/181

## Solution
<!-- A summary of the solution addressing the above issue -->
### Summary

Replaces the three hardcoded worker modules (`mimir_backend`, `mimir_read`, `mimir_write`) with a single `module.mimir_worker` using `for_each` over a `var.workers` map. This enables both microservices and monolithic deployment modes from the same module interface.

### Motivation

- Reduce duplication: all three worker modules were identical except for the role config key
- Enable monolithic mode (`role-all`) with a single worker instead of three
- Simplify the variable interface from ~15 per-role variables to one structured map

### Usage

**Microservices (default, same as before):**
```hcl
module "mimir" {
  source = "git::https://github.com/canonical/mimir-operators//terraform"
  # ...
  workers = {
    backend = { units = 3 }
    read    = { units = 2, storage_directives = { "data" = "10G" } }
    write   = { units = 2 }
  }
}
```

**Monolithic (single worker with all roles):**
```hcl
module "mimir" {
  source = "git::https://github.com/canonical/mimir-operators//terraform"
  # ...
  workers = {
    all = { units = 3 }
  }
}
```

### Breaking Changes

| Before | After |
|--------|-------|
| `var.backend_name` / `var.read_name` / `var.write_name` | `var.workers.<role>.app_name` |
| `var.backend_config` / `var.read_config` / `var.write_config` | `var.workers.<role>.config` |
| `var.backend_units` / `var.read_units` / `var.write_units` | `var.workers.<role>.units` |
| `var.backend_worker_storage_directives` / etc. | `var.workers.<role>.storage_directives` |
| `var.worker_constraints` | `var.workers.<role>.constraints` |
| `module.mimir_backend` / `module.mimir_read` / `module.mimir_write` | `module.mimir_worker["backend"]` / `["read"]` / `["write"]` |
| `juju_integration.coordinator_to_backend` / etc. | `juju_integration.coordinator_to_worker["backend"]` / etc. |

**State migration:** Existing deployments will need to recreate worker resources. The Terraform state addresses change due to the `for_each` refactor.

### Validations

- Worker map keys restricted to `["all", "backend", "read", "write"]`
- `"all"` cannot coexist with other role keys
- Per-worker units must be >= 1
- Anti-affinity (top-level bool) overrides per-worker constraints when enabled

### Unchanged

- Coordinator module, S3 integrator, and their variables remain the same
- `var.worker_resources` and `var.worker_revision` remain top-level (shared across all workers)
- `provides`/`requires` outputs unchanged
- `app_names` output now dynamically includes whichever workers are deployed

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
- [ ] Add unit tests to assert features work

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
