### PR TITLE
feat(terraform): conditional s3 integrator support

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,7 +34,12 @@ module "mimir_worker" {
 
 # -------------- # S3-integrator --------------
 
+locals {
+  deploy_s3 = var.s3_endpoint != null
+}
+
 resource "juju_secret" "mimir_s3_credentials_secret" {
+  count      = local.deploy_s3 ? 1 : 0
   model_uuid = var.model_uuid
   name       = "mimir_s3_credentials"
   value = {
@@ -45,18 +50,20 @@ resource "juju_secret" "mimir_s3_credentials_secret" {
 }
 
 resource "juju_access_secret" "mimir_s3_secret_access" {
+  count      = local.deploy_s3 ? 1 : 0
   model_uuid = var.model_uuid
   applications = [
-    juju_application.s3_integrator.name
+    juju_application.s3_integrator[0].name
   ]
-  secret_id = juju_secret.mimir_s3_credentials_secret.secret_id
+  secret_id = juju_secret.mimir_s3_credentials_secret[0].secret_id
 }
 
 resource "juju_application" "s3_integrator" {
+  count = local.deploy_s3 ? 1 : 0
   config = merge({
     endpoint    = var.s3_endpoint
     bucket      = var.s3_bucket
-    credentials = "secret:${juju_secret.mimir_s3_credentials_secret.secret_id}"
+    credentials = "secret:${juju_secret.mimir_s3_credentials_secret[0].secret_id}"
   }, var.s3_integrator_config)
   constraints        = var.s3_integrator_constraints
   model_uuid         = var.model_uuid
@@ -75,9 +82,10 @@ resource "juju_application" "s3_integrator" {
 # -------------- # Integrations --------------
 
 resource "juju_integration" "coordinator_to_s3_integrator" {
+  count      = local.deploy_s3 ? 1 : 0
   model_uuid = var.model_uuid
   application {
-    name     = juju_application.s3_integrator.name
+    name     = juju_application.s3_integrator[0].name
     endpoint = "s3-credentials"
   }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,9 +1,9 @@
 output "app_names" {
   value = merge(
     {
-      mimir_s3_integrator = juju_application.s3_integrator.name,
-      mimir_coordinator   = module.mimir_coordinator.app_name,
+      mimir_coordinator = module.mimir_coordinator.app_name,
     },
+    local.deploy_s3 ? { mimir_s3_integrator = juju_application.s3_integrator[0].name } : {},
     { for k, v in module.mimir_worker : "mimir_${k}" => v.app_name }
   )
   description = "All application names which make up this product module"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,19 +34,30 @@ variable "s3_bucket" {
 }
 
 variable "s3_access_key" {
-  description = "S3 access-key credential"
+  description = "S3 access-key credential. Set to null (along with s3_endpoint and s3_secret_key) to skip deploying the S3 integrator."
   type        = string
+  default     = null
 }
 
 variable "s3_secret_key" {
-  description = "S3 secret-key credential"
+  description = "S3 secret-key credential. Set to null (along with s3_endpoint and s3_access_key) to skip deploying the S3 integrator."
   type        = string
   sensitive   = true
+  default     = null
 }
 
 variable "s3_endpoint" {
-  description = "S3 endpoint"
+  description = "S3 endpoint. When null, the S3 integrator is not deployed and the caller must handle storage integration externally."
   type        = string
+  default     = null
+
+  validation {
+    condition = (
+      (var.s3_endpoint == null && var.s3_access_key == null && var.s3_secret_key == null) ||
+      (var.s3_endpoint != null && var.s3_access_key != null && var.s3_secret_key != null)
+    )
+    error_message = "s3_endpoint, s3_access_key, and s3_secret_key must all be set or all be null."
+  }
 }
 
 # -------------- # Workers --------------


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->


## Solution
<!-- A summary of the solution addressing the above issue -->
### Summary

Two major changes to the Mimir Terraform module:
1. Replace three hardcoded worker modules with a single `for_each`-based module supporting dynamic roles including monolithic mode
2. Make the S3 integrator conditional — callers can use external storage backends (e.g. SeaweedFS)

### Motivation

- **Worker duplication:** `mimir_backend`, `mimir_read`, `mimir_write` were identical modules differing only in the role config key. This made it impossible to deploy in monolithic mode (`role-all`) without a code change.
- **Storage flexibility:** The S3 integrator was always deployed, preventing use cases where storage is provided externally (e.g. SeaweedFS integrated at the product module level).

### Dynamic Workers

The three worker modules are replaced by a single `module.mimir_worker` with `for_each` over `var.workers`:

```hcl
# Microservices (default):
workers = {
  backend = { units = 3, storage_directives = { "data" = "50G" } }
  read    = { units = 2 }
  write   = { units = 2 }
}

# Monolithic:
workers = {
  all = { units = 3 }
}
```

Each worker entry supports: `units`, `config`, `constraints`, `storage_directives`, `app_name` (all optional with sensible defaults). The role config (`role-backend = true`, etc.) is injected automatically from the map key.

**Validations:**
- Keys must be one of: `all`, `backend`, `read`, `write`
- `all` cannot coexist with other role keys
- Units must be >= 1

**Anti-affinity:** The top-level `var.anti_affinity` bool overrides per-worker `constraints` when enabled, computing anti-affinity tags from the resolved app name.

### Optional S3 Integrator

When `var.s3_endpoint` is `null` (the new default), no S3 resources are created:
- `juju_secret.mimir_s3_credentials_secret`
- `juju_access_secret.mimir_s3_secret_access`
- `juju_application.s3_integrator`
- `juju_integration.coordinator_to_s3_integrator`

The caller is responsible for integrating their chosen storage backend with the coordinator's `s3` endpoint.

**Validation:** `s3_endpoint`, `s3_access_key`, and `s3_secret_key` must all be set or all be null.

### Breaking Changes

| Before | After |
|--------|-------|
| `var.backend_name` / `var.read_name` / `var.write_name` | `var.workers.<role>.app_name` |
| `var.backend_config` / `var.read_config` / `var.write_config` | `var.workers.<role>.config` |
| `var.backend_units` / `var.read_units` / `var.write_units` | `var.workers.<role>.units` |
| `var.backend_worker_storage_directives` / etc. | `var.workers.<role>.storage_directives` |
| `var.worker_constraints` | `var.workers.<role>.constraints` |
| `var.s3_endpoint` (required) | `var.s3_endpoint` (optional, default `null`) |
| `var.s3_access_key` (required) | `var.s3_access_key` (optional, default `null`) |
| `var.s3_secret_key` (required) | `var.s3_secret_key` (optional, default `null`) |
| `module.mimir_backend` | `module.mimir_worker["backend"]` |
| `juju_integration.coordinator_to_backend` | `juju_integration.coordinator_to_worker["backend"]` |

**State migration:** Existing deployments will need to recreate worker and integration resources due to the `for_each` address change. S3 resources gain a `[0]` index.

### Unchanged

- Coordinator module and its variables
- `var.worker_resources` and `var.worker_revision` (shared across all workers)
- `provides` / `requires` outputs
- All `s3_integrator_*` customization variables (channel, name, config, etc.)

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
