### PR TITLE
feat(terraform): Testing

### DIFF
--- a/coordinator/terraform/README.md
+++ b/coordinator/terraform/README.md
@@ -3,13 +3,6 @@
 This is a Terraform module facilitating the deployment of mimir-coordinator-k8s charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0 |
-
 ## Providers
 
 | Name | Version |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,13 +6,6 @@ This is a Terraform module facilitating the deployment of Mimir solution, using 
 > `s3-integrator` itself doesn't act as an S3 object storage system. For the HA solution to be functional, `s3-integrator` needs to point to an S3-like storage. See [this guide](https://discourse.charmhub.io/t/cos-lite-docs-set-up-minio/15211) to learn how to connect to an S3-like storage for traces.
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0 |
-
 ## Providers
 
 | Name | Version |
@@ -23,20 +16,14 @@ This is a Terraform module facilitating the deployment of Mimir solution, using 
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mimir_backend"></a> [mimir\_backend](#module\_mimir\_backend) | ../worker/terraform | n/a |
 | <a name="module_mimir_coordinator"></a> [mimir\_coordinator](#module\_mimir\_coordinator) | ../coordinator/terraform | n/a |
-| <a name="module_mimir_read"></a> [mimir\_read](#module\_mimir\_read) | ../worker/terraform | n/a |
-| <a name="module_mimir_write"></a> [mimir\_write](#module\_mimir\_write) | ../worker/terraform | n/a |
+| <a name="module_mimir_worker"></a> [mimir\_worker](#module\_mimir\_worker) | ../worker/terraform | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_anti_affinity"></a> [anti\_affinity](#input\_anti\_affinity) | Enable anti-affinity constraints. | `bool` | `true` | no |
-| <a name="input_backend_config"></a> [backend\_config](#input\_backend\_config) | Map of the backend worker configuration options | `map(string)` | `{}` | no |
-| <a name="input_backend_name"></a> [backend\_name](#input\_backend\_name) | Name of the Mimir backend (meta role) app | `string` | `"mimir-backend"` | no |
-| <a name="input_backend_units"></a> [backend\_units](#input\_backend\_units) | Number of Mimir worker units with the backend meta role | `number` | `1` | no |
-| <a name="input_backend_worker_storage_directives"></a> [backend\_worker\_storage\_directives](#input\_backend\_worker\_storage\_directives) | Map of storage used by the backend worker application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
 | <a name="input_channel"></a> [channel](#input\_channel) | Channel that the applications are deployed from | `string` | n/a | yes |
 | <a name="input_coordinator_config"></a> [coordinator\_config](#input\_coordinator\_config) | Map of the coordinator configuration options | `map(string)` | `{}` | no |
 | <a name="input_coordinator_constraints"></a> [coordinator\_constraints](#input\_coordinator\_constraints) | String listing constraints for the coordinator application | `string` | `"arch=amd64"` | no |
@@ -45,13 +32,9 @@ This is a Terraform module facilitating the deployment of Mimir solution, using 
 | <a name="input_coordinator_storage_directives"></a> [coordinator\_storage\_directives](#input\_coordinator\_storage\_directives) | Map of storage used by the coordinator application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
 | <a name="input_coordinator_units"></a> [coordinator\_units](#input\_coordinator\_units) | Number of Mimir coordinator units | `number` | `1` | no |
 | <a name="input_model_uuid"></a> [model\_uuid](#input\_model\_uuid) | Reference to an existing model resource or data source for the model to deploy to | `string` | n/a | yes |
-| <a name="input_read_config"></a> [read\_config](#input\_read\_config) | Map of the read worker configuration options | `map(string)` | `{}` | no |
-| <a name="input_read_name"></a> [read\_name](#input\_read\_name) | Name of the Mimir read (meta role) app | `string` | `"mimir-read"` | no |
-| <a name="input_read_units"></a> [read\_units](#input\_read\_units) | Number of Mimir worker units with the read meta role | `number` | `1` | no |
-| <a name="input_read_worker_storage_directives"></a> [read\_worker\_storage\_directives](#input\_read\_worker\_storage\_directives) | Map of storage used by the read worker application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
-| <a name="input_s3_access_key"></a> [s3\_access\_key](#input\_s3\_access\_key) | S3 access-key credential | `string` | n/a | yes |
+| <a name="input_s3_access_key"></a> [s3\_access\_key](#input\_s3\_access\_key) | S3 access-key credential. Set to null (along with s3\_endpoint and s3\_secret\_key) to skip deploying the S3 integrator. | `string` | `null` | no |
 | <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | Bucket name | `string` | `"mimir"` | no |
-| <a name="input_s3_endpoint"></a> [s3\_endpoint](#input\_s3\_endpoint) | S3 endpoint | `string` | n/a | yes |
+| <a name="input_s3_endpoint"></a> [s3\_endpoint](#input\_s3\_endpoint) | S3 endpoint. When null, the S3 integrator is not deployed and the caller must handle storage integration externally. | `string` | `null` | no |
 | <a name="input_s3_integrator_channel"></a> [s3\_integrator\_channel](#input\_s3\_integrator\_channel) | Channel that the s3-integrator application is deployed from | `string` | `"2/stable"` | no |
 | <a name="input_s3_integrator_config"></a> [s3\_integrator\_config](#input\_s3\_integrator\_config) | Map of the s3-integrator configuration options | `map(string)` | `{}` | no |
 | <a name="input_s3_integrator_constraints"></a> [s3\_integrator\_constraints](#input\_s3\_integrator\_constraints) | String listing constraints for the s3-integrator application | `string` | `"arch=amd64"` | no |
@@ -59,14 +42,10 @@ This is a Terraform module facilitating the deployment of Mimir solution, using 
 | <a name="input_s3_integrator_revision"></a> [s3\_integrator\_revision](#input\_s3\_integrator\_revision) | Revision number of the s3-integrator application | `number` | `null` | no |
 | <a name="input_s3_integrator_storage_directives"></a> [s3\_integrator\_storage\_directives](#input\_s3\_integrator\_storage\_directives) | Map of storage used by the s3-integrator application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
 | <a name="input_s3_integrator_units"></a> [s3\_integrator\_units](#input\_s3\_integrator\_units) | Number of S3 integrator units | `number` | `1` | no |
-| <a name="input_s3_secret_key"></a> [s3\_secret\_key](#input\_s3\_secret\_key) | S3 secret-key credential | `string` | n/a | yes |
-| <a name="input_worker_constraints"></a> [worker\_constraints](#input\_worker\_constraints) | String listing constraints for the worker application | `string` | `"arch=amd64"` | no |
+| <a name="input_s3_secret_key"></a> [s3\_secret\_key](#input\_s3\_secret\_key) | S3 secret-key credential. Set to null (along with s3\_endpoint and s3\_access\_key) to skip deploying the S3 integrator. | `string` | `null` | no |
 | <a name="input_worker_resources"></a> [worker\_resources](#input\_worker\_resources) | The worker application's resources i.e., a resource revision number from CharmHub or a custom OCI image resource | `map(string)` | `{}` | no |
 | <a name="input_worker_revision"></a> [worker\_revision](#input\_worker\_revision) | Revision number of the worker application | `number` | `null` | no |
-| <a name="input_write_config"></a> [write\_config](#input\_write\_config) | Map of the write worker configuration options | `map(string)` | `{}` | no |
-| <a name="input_write_name"></a> [write\_name](#input\_write\_name) | Name of the Mimir write (meta role) app | `string` | `"mimir-write"` | no |
-| <a name="input_write_units"></a> [write\_units](#input\_write\_units) | Number of Mimir worker units with the write meta role | `number` | `1` | no |
-| <a name="input_write_worker_storage_directives"></a> [write\_worker\_storage\_directives](#input\_write\_worker\_storage\_directives) | Map of storage used by the write worker application, which defaults to 1 GB, allocated by Juju | `map(string)` | `{}` | no |
+| <a name="input_workers"></a> [workers](#input\_workers) | Map of worker roles to deploy. Keys must be one of: all, backend, read, write. When 'all' is used, a single worker with role-all is created. | <pre>map(object({<br/>    units              = optional(number, 1)<br/>    config             = optional(map(string), {})<br/>    constraints        = optional(string, "arch=amd64")<br/>    storage_directives = optional(map(string), {})<br/>    app_name           = optional(string)<br/>  }))</pre> | <pre>{<br/>  "backend": {},<br/>  "read": {},<br/>  "write": {}<br/>}</pre> | no |
 
 ## Outputs
 
@@ -79,7 +58,110 @@ This is a Terraform module facilitating the deployment of Mimir solution, using 
 
 ## Usage
 
-### Microservice deployment
+### Microservices deployment (default)
 
-By default, this Terraform module will deploy each Mimir worker with `1` unit. To configure the module to run `x` units of any worker role, you can run `terraform apply -var="<ROLE>_units=<x>"`.
+By default, this module deploys three separate workers — `backend`, `read`, and `write` — each with 1 unit:
+
+```hcl
+module "mimir" {
+  source     = "git::https://github.com/canonical/mimir-operators//terraform"
+  model_uuid = juju_model.cos.uuid
+  channel    = "dev/edge"
+
+  s3_endpoint   = "https://s3.example.com"
+  s3_access_key = "my-access-key"
+  s3_secret_key = "my-secret-key"
+}
+```
+
+To scale individual roles:
+
+```hcl
+module "mimir" {
+  source     = "git::https://github.com/canonical/mimir-operators//terraform"
+  model_uuid = juju_model.cos.uuid
+  channel    = "dev/edge"
+
+  workers = {
+    backend = { units = 3, storage_directives = { "data" = "50G" } }
+    read    = { units = 2 }
+    write   = { units = 2 }
+  }
+
+  s3_endpoint   = "https://s3.example.com"
+  s3_access_key = "my-access-key"
+  s3_secret_key = "my-secret-key"
+}
+```
+
 See [Mimir worker roles](https://discourse.charmhub.io/t/mimir-worker-roles/15484) for the recommended scale for each role.
+
+### Monolithic deployment
+
+To deploy a single worker with all roles combined:
+
+```hcl
+module "mimir" {
+  source     = "git::https://github.com/canonical/mimir-operators//terraform"
+  model_uuid = juju_model.cos.uuid
+  channel    = "dev/edge"
+
+  workers = {
+    all = { units = 3 }
+  }
+
+  s3_endpoint   = "https://s3.example.com"
+  s3_access_key = "my-access-key"
+  s3_secret_key = "my-secret-key"
+}
+```
+
+> [!NOTE]
+> When using `all`, no other worker roles may be specified.
+
+### External storage backend (no S3 integrator)
+
+When using an external storage backend (e.g. SeaweedFS), omit the `s3_*` variables. The module will not deploy the S3 integrator, and you are responsible for integrating your storage with the coordinator's `s3` endpoint:
+
+```hcl
+module "mimir" {
+  source     = "git::https://github.com/canonical/mimir-operators//terraform"
+  model_uuid = juju_model.cos.uuid
+  channel    = "dev/edge"
+
+  workers = {
+    backend = { units = 2 }
+    read    = { units = 2 }
+    write   = { units = 2 }
+  }
+}
+
+# Wire external storage to the coordinator
+resource "juju_integration" "seaweedfs_mimir" {
+  model_uuid = juju_model.cos.uuid
+
+  application {
+    name     = module.seaweedfs.app_name
+    endpoint = module.seaweedfs.provides.s3
+  }
+
+  application {
+    name     = module.mimir.app_names.mimir_coordinator
+    endpoint = module.mimir.requires.s3
+  }
+}
+```
+
+### Worker configuration options
+
+Each entry in the `workers` map accepts:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `units` | `number` | `1` | Number of units for this worker role |
+| `config` | `map(string)` | `{}` | Charm configuration options |
+| `constraints` | `string` | `"arch=amd64"` | Juju constraints (ignored when `anti_affinity = true`) |
+| `storage_directives` | `map(string)` | `{}` | Storage directives for this worker |
+| `app_name` | `string` | `"mimir-<role>"` | Override the application name |
+
+Valid worker keys: `all`, `backend`, `read`, `write`.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -151,17 +151,3 @@ resource "juju_integration" "seaweedfs_mimir" {
   }
 }
 ```
-
-### Worker configuration options
-
-Each entry in the `workers` map accepts:
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `units` | `number` | `1` | Number of units for this worker role |
-| `config` | `map(string)` | `{}` | Charm configuration options |
-| `constraints` | `string` | `"arch=amd64"` | Juju constraints (ignored when `anti_affinity = true`) |
-| `storage_directives` | `map(string)` | `{}` | Storage directives for this worker |
-| `app_name` | `string` | `"mimir-<role>"` | Override the application name |
-
-Valid worker keys: `all`, `backend`, `read`, `write`.

--- a/terraform/tests/s3_optional.tftest.hcl
+++ b/terraform/tests/s3_optional.tftest.hcl
@@ -1,0 +1,64 @@
+mock_provider "juju" {}
+
+variables {
+  model_uuid  = "00000000-0000-0000-0000-000000000000"
+  channel     = "dev/edge"
+}
+
+# --- default: S3 disabled (no integrator deployed) ---
+
+run "s3_disabled_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(juju_application.s3_integrator) == 0
+    error_message = "Expected no s3-integrator when s3_endpoint is null"
+  }
+
+  assert {
+    condition     = length(juju_secret.mimir_s3_credentials_secret) == 0
+    error_message = "Expected no s3 credentials secret when s3_endpoint is null"
+  }
+
+  assert {
+    condition     = length(juju_access_secret.mimir_s3_secret_access) == 0
+    error_message = "Expected no s3 access secret when s3_endpoint is null"
+  }
+
+  assert {
+    condition     = length(juju_integration.coordinator_to_s3_integrator) == 0
+    error_message = "Expected no s3 integration when s3_endpoint is null"
+  }
+}
+
+# --- S3 enabled: all resources created ---
+
+run "s3_enabled" {
+  command = plan
+
+  variables {
+    s3_endpoint   = "https://s3.example.com"
+    s3_access_key = "access-key"
+    s3_secret_key = "secret-key"
+  }
+
+  assert {
+    condition     = length(juju_application.s3_integrator) == 1
+    error_message = "Expected s3-integrator when s3_endpoint is set"
+  }
+
+  assert {
+    condition     = length(juju_secret.mimir_s3_credentials_secret) == 1
+    error_message = "Expected s3 credentials secret when s3_endpoint is set"
+  }
+
+  assert {
+    condition     = length(juju_access_secret.mimir_s3_secret_access) == 1
+    error_message = "Expected s3 access secret when s3_endpoint is set"
+  }
+
+  assert {
+    condition     = length(juju_integration.coordinator_to_s3_integrator) == 1
+    error_message = "Expected s3 integration when s3_endpoint is set"
+  }
+}

--- a/terraform/tests/validation.tftest.hcl
+++ b/terraform/tests/validation.tftest.hcl
@@ -1,0 +1,92 @@
+mock_provider "juju" {}
+
+variables {
+  model_uuid  = "00000000-0000-0000-0000-000000000000"
+  channel     = "dev/edge"
+}
+
+# --- invalid worker key ---
+
+run "invalid_worker_key" {
+  command         = plan
+  expect_failures = [var.workers]
+
+  variables {
+    workers = {
+      invalid_role = {}
+    }
+  }
+}
+
+# --- role-all with other roles ---
+
+run "all_with_other_roles" {
+  command         = plan
+  expect_failures = [var.workers]
+
+  variables {
+    workers = {
+      all     = {}
+      backend = {}
+    }
+  }
+}
+
+# --- zero units ---
+
+run "zero_units" {
+  command         = plan
+  expect_failures = [var.workers]
+
+  variables {
+    workers = {
+      backend = { units = 0 }
+    }
+  }
+}
+
+# --- partial S3 config: endpoint without credentials ---
+
+run "s3_endpoint_without_credentials" {
+  command         = plan
+  expect_failures = [var.s3_endpoint]
+
+  variables {
+    s3_endpoint = "https://s3.example.com"
+  }
+}
+
+# --- partial S3 config: credentials without endpoint ---
+
+run "s3_credentials_without_endpoint" {
+  command         = plan
+  expect_failures = [var.s3_endpoint]
+
+  variables {
+    s3_access_key = "access-key"
+    s3_secret_key = "secret-key"
+  }
+}
+
+# --- invalid channel track ---
+
+run "invalid_channel" {
+  command         = plan
+  expect_failures = [var.channel]
+
+  variables {
+    channel = "stable"
+  }
+}
+
+# --- anti-affinity with custom coordinator constraints ---
+
+run "anti_affinity_with_custom_coordinator_constraints" {
+  command         = plan
+  expect_failures = [var.coordinator_constraints]
+
+  variables {
+    anti_affinity            = true
+    coordinator_constraints  = "arch=arm64"
+  }
+}

--- a/terraform/tests/workers.tftest.hcl
+++ b/terraform/tests/workers.tftest.hcl
@@ -1,0 +1,120 @@
+mock_provider "juju" {}
+
+variables {
+  model_uuid  = "00000000-0000-0000-0000-000000000000"
+  channel     = "dev/edge"
+}
+
+# --- default: three workers (backend, read, write) ---
+
+run "default_workers" {
+  command = plan
+
+  assert {
+    condition     = length(module.mimir_worker) == 3
+    error_message = "Expected 3 worker modules with default workers config"
+  }
+
+  assert {
+    condition     = length(juju_integration.coordinator_to_worker) == 3
+    error_message = "Expected 3 coordinator-to-worker integrations"
+  }
+}
+
+# --- monolithic mode: single worker with role-all ---
+
+run "monolithic_mode" {
+  command = plan
+
+  variables {
+    workers = {
+      all = {}
+    }
+  }
+
+  assert {
+    condition     = length(module.mimir_worker) == 1
+    error_message = "Expected 1 worker module in monolithic mode"
+  }
+
+  assert {
+    condition     = length(juju_integration.coordinator_to_worker) == 1
+    error_message = "Expected 1 coordinator-to-worker integration in monolithic mode"
+  }
+}
+
+# --- custom units per worker ---
+
+run "custom_units" {
+  command = plan
+
+  variables {
+    workers = {
+      backend = { units = 3 }
+      read    = { units = 2 }
+      write   = { units = 5 }
+    }
+  }
+
+  assert {
+    condition     = module.mimir_worker["backend"].app_name == "mimir-backend"
+    error_message = "Expected backend worker app_name to be mimir-backend"
+  }
+
+  assert {
+    condition     = module.mimir_worker["read"].app_name == "mimir-read"
+    error_message = "Expected read worker app_name to be mimir-read"
+  }
+
+  assert {
+    condition     = module.mimir_worker["write"].app_name == "mimir-write"
+    error_message = "Expected write worker app_name to be mimir-write"
+  }
+}
+
+# --- custom app_name override ---
+
+run "custom_app_name" {
+  command = plan
+
+  variables {
+    workers = {
+      backend = { app_name = "my-backend" }
+      read    = {}
+      write   = {}
+    }
+  }
+
+  assert {
+    condition     = module.mimir_worker["backend"].app_name == "my-backend"
+    error_message = "Expected custom app_name to be used"
+  }
+
+  assert {
+    condition     = module.mimir_worker["read"].app_name == "mimir-read"
+    error_message = "Expected default app_name mimir-read"
+  }
+}
+
+# --- subset of workers (only read and write) ---
+
+run "subset_workers" {
+  command = plan
+
+  variables {
+    workers = {
+      read  = { units = 2 }
+      write = { units = 2 }
+    }
+  }
+
+  assert {
+    condition     = length(module.mimir_worker) == 2
+    error_message = "Expected 2 worker modules"
+  }
+
+  assert {
+    condition     = length(juju_integration.coordinator_to_worker) == 2
+    error_message = "Expected 2 coordinator-to-worker integrations"
+  }
+}

--- a/worker/terraform/README.md
+++ b/worker/terraform/README.md
@@ -3,13 +3,6 @@
 This is a Terraform module facilitating the deployment of mimir-worker-k8s charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
 
 <!-- BEGIN_TF_DOCS -->
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_juju"></a> [juju](#requirement\_juju) | >= 1.0 |
-
 ## Providers
 
 | Name | Version |


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->


## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
### Deploy a distributed mimir

```hcl
terraform {
  required_providers {
    juju = {
      source  = "juju/juju"
      version = "~> 1.0"
    }
  }
}

resource "juju_model" "mimir" {
  name = "mimir-v2"
}

module "mimir" {
  source     = "git::https://github.com/canonical/mimir-operators//terraform?ref=feat/monolithic-option-3"
  model_uuid = juju_model.mimir.uuid
  channel    = "dev/edge"
  workers = {
    backend = { units = 1 }
    read    = { units = 1 }
    write   = { units = 1 }
  }
}

module "seaweedfs" {
  source     = "git::https://github.com/canonical/observability-stack//terraform/seaweedfs"
  model_uuid = juju_model.mimir.uuid
}

resource "juju_integration" "seaweedfs_mimir" {
  model_uuid = juju_model.mimir.uuid
  application {
    name     = module.seaweedfs.app_name
    endpoint = module.seaweedfs.provides.s3
  }
  application {
    name     = module.mimir.app_names.mimir_coordinator
    endpoint = module.mimir.requires.s3
  }
}
```
> Apply complete! Resources: 10 added, 0 changed, 0 destroyed.
<img width="636" height="398" alt="image" src="https://github.com/user-attachments/assets/7ee1a94e-252c-4a8b-8b0d-d6c66c64b4c3" />

### Update to monolithic mimir

```hcl
module "mimir" {
  source     = "git::https://github.com/canonical/mimir-operators//terraform?ref=feat/monolithic-option-3"
  model_uuid = juju_model.mimir.uuid
  channel    = "dev/edge"
  workers = { all = { units = 1 } }
}
```

> Apply complete! Resources: 2 added, 0 changed, 6 destroyed.
<img width="606" height="299" alt="image" src="https://github.com/user-attachments/assets/b79329fa-957f-4164-bde1-d68e38c49915" />

### When s3_endpoint is provided, validation for integrations triggers, user needs to remove the seaweedfs integration to resolve the error

then add the s3 endpoint information (simulating microceph):
```hcl
module "mimir" {
  source     = "git::https://github.com/canonical/mimir-operators//terraform?ref=feat/monolithic-option-3"
  model_uuid = juju_model.mimir.uuid
  channel    = "dev/edge"

  workers = { all = { units = 1 } }

  s3_endpoint   = "http://10.1.0.122:8333"
  s3_access_key = "placeholder"
  s3_secret_key = "placeholder"
}
```

but we get a client error because we have 2 integrations to an s3-integrator:
```
│ Error: Client Error
│ 
│   with module.mimir.juju_integration.coordinator_to_s3_integrator[0],
│   on .terraform/modules/mimir/terraform/main.tf line 84, in resource "juju_integration" "coordinator_to_s3_integrator":
│   84: resource "juju_integration" "coordinator_to_s3_integrator" {
│ 
│ Unable to create integration, got error: cannot add relation "mimir:s3
│ mimir-s3-integrator:s3-credentials": establishing a new relation for
│ mimir:s3 would exceed its maximum relation limit of 1 (quota limit
│ exceeded)
```

so we have to remove that integration in the root module:
```diff
-resource "juju_integration" "seaweedfs_mimir" {
-  model_uuid = juju_model.mimir.uuid
-  application {
-    name     = module.seaweedfs.app_name
-    endpoint = module.seaweedfs.provides.s3
-  }
-  application {
-    name     = module.mimir.app_names.mimir_coordinator
-    endpoint = module.mimir.requires.s3
-  }
-}
```
> Apply complete! Resources: 4 added, 0 changed, 1 destroyed.
<img width="687" height="348" alt="image" src="https://github.com/user-attachments/assets/d432f3bf-35c1-4b89-84cb-1ba74344f202" />

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
