### PR TITLE
feat: use seaweedfs in itests instead of Minio

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
         charm-path:
           - coordinator
           - worker
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@fix/quality-checks-controller-name
     secrets: inherit
     with:
       charm-path: ${{ matrix.charm-path }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
         charm-path:
           - coordinator
           - worker
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@fix/remove-juju-default-qualit-checks
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
     secrets: inherit
     with:
       charm-path: ${{ matrix.charm-path }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
         charm-path:
           - coordinator
           - worker
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@fix/quality-checks-controller-name
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
     secrets: inherit
     with:
       charm-path: ${{ matrix.charm-path }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -18,7 +18,7 @@ jobs:
         charm-path:
           - coordinator
           - worker
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@fix/quality-checks-controller-name
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@fix/remove-juju-default-qualit-checks
     secrets: inherit
     with:
       charm-path: ${{ matrix.charm-path }}

--- a/coordinator/pyproject.toml
+++ b/coordinator/pyproject.toml
@@ -23,7 +23,6 @@ dev = [
   "coverage[toml]",
   "deepdiff",
   # Integration
-  "minio",
   "tenacity",
   "juju",
   "jubilant",

--- a/coordinator/uv.lock
+++ b/coordinator/uv.lock
@@ -25,39 +25,6 @@ wheels = [
 ]
 
 [[package]]
-name = "argon2-cffi"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "argon2-cffi-bindings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
-]
-
-[[package]]
-name = "argon2-cffi-bindings"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
-    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
-    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
-    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
-    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
-]
-
-[[package]]
 name = "backports-datetime-fromisoformat"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -636,7 +603,6 @@ dev = [
     { name = "deepdiff" },
     { name = "jubilant" },
     { name = "juju" },
-    { name = "minio" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "ops", extra = ["testing"] },
@@ -658,7 +624,6 @@ requires-dist = [
     { name = "jubilant", marker = "extra == 'dev'" },
     { name = "juju", marker = "extra == 'dev'" },
     { name = "lightkube-extensions" },
-    { name = "minio", marker = "extra == 'dev'" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'dev'" },
     { name = "opentelemetry-sdk", marker = "extra == 'dev'" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'", specifier = ">=2.17" },
@@ -670,22 +635,6 @@ requires-dist = [
     { name = "tenacity", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
-
-[[package]]
-name = "minio"
-version = "7.2.20"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "argon2-cffi" },
-    { name = "certifi" },
-    { name = "pycryptodome" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/df/6dfc6540f96a74125a11653cce717603fd5b7d0001a8e847b3e54e72d238/minio-7.2.20.tar.gz", hash = "sha256:95898b7a023fbbfde375985aa77e2cd6a0762268db79cf886f002a9ea8e68598", size = 136113, upload-time = "2025-11-27T00:37:15.569Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/9a/b697530a882588a84db616580f2ba5d1d515c815e11c30d219145afeec87/minio-7.2.20-py3-none-any.whl", hash = "sha256:eb33dd2fb80e04c3726a76b13241c6be3c4c46f8d81e1d58e757786f6501897e", size = 93751, upload-time = "2025-11-27T00:37:13.993Z" },
-]
 
 [[package]]
 name = "mypy-extensions"
@@ -931,25 +880,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
-name = "pycryptodome"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
-    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
-    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
-    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
-    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
-    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,7 +10,6 @@ import requests
 import yaml
 from lightkube import Client
 from lightkube.generic_resource import create_namespaced_resource
-from minio import Minio
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
@@ -22,6 +21,8 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 logger = logging.getLogger(__name__)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+SWFS_APP = "swfs"
+SWFS_CHANNEL = "latest/edge"
 
 
 def charm_resources(metadata_file: str | None = None) -> dict[str, str]:
@@ -53,39 +54,10 @@ def get_unit_address(juju: jubilant.Juju, app_name: str, unit_no: int) -> str:
     return unit.address
 
 
-@retry(wait=wait_fixed(5), stop=stop_after_attempt(12))
-def _wait_for_minio_ready(minio_addr: str):
-    """Poll MinIO's readiness endpoint until the S3 API is actually serving."""
-    response = requests.get(f"http://{minio_addr}:9000/minio/health/ready", timeout=5)
-    assert response.status_code == 200, (
-        f"MinIO readiness check returned HTTP {response.status_code}"
-    )
-
-
-def configure_minio(juju: jubilant.Juju):
-    bucket_name = "mimir"
-    minio_addr = get_leader_address(juju, "minio")
-    _wait_for_minio_ready(minio_addr)
-    mc_client = Minio(
-        f"{minio_addr}:9000",
-        access_key="access",
-        secret_key="secretsecret",
-        secure=False,
-    )
-    if not mc_client.bucket_exists(bucket_name):
-        mc_client.make_bucket(bucket_name)
-
-
-def configure_s3_integrator(juju: jubilant.Juju):
-    model_name = juju.status().model.name
-    juju.config("s3", {
-        "endpoint": f"minio-0.minio-endpoints.{model_name}.svc.cluster.local:9000",
-        "bucket": "mimir",
-    })
-    juju.run("s3/leader", "sync-s3-credentials", {
-        "access-key": "access",
-        "secret-key": "secretsecret",
-    })
+def deploy_swfs(juju: jubilant.Juju, swfs_app: str = SWFS_APP):
+    """Deploy SeaweedFS as an S3 test backend."""
+    juju.deploy("seaweedfs-k8s", swfs_app, channel=SWFS_CHANNEL)
+    juju.wait(lambda s: jubilant.all_active(s, swfs_app), timeout=1000)
 
 
 def get_grafana_datasources_from_client_localhost(

--- a/tests/integration/test_charm_ha.py
+++ b/tests/integration/test_charm_ha.py
@@ -11,8 +11,7 @@ import pytest
 import requests
 from helpers import (
     charm_resources,
-    configure_minio,
-    configure_s3_integrator,
+    deploy_swfs,
     get_grafana_datasources_from_client_localhost,
     get_mimir_rules_from_grafana,
     get_prometheus_targets_from_client_localhost,
@@ -33,25 +32,14 @@ def test_build_and_deploy(juju: jubilant.Juju, mimir_charm: str, cos_channel):
     juju.deploy("grafana-k8s", "grafana", channel=cos_channel, trust=True)
     juju.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True)
     juju.deploy("opentelemetry-collector-k8s", "otelcol", trust=True, channel=cos_channel)
-    # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
-    juju.deploy(
-        "minio",
-        channel="ckf-1.9/stable",
-        config={"access-key": "access", "secret-key": "secretsecret"},
-    )
-    juju.deploy("s3-integrator", "s3", channel="latest/stable")
-
-    juju.wait(lambda s: jubilant.all_active(s, "minio"), timeout=1000)
-    juju.wait(lambda s: jubilant.all_blocked(s, "s3"), timeout=1000)
-    configure_minio(juju)
-    configure_s3_integrator(juju)
+    deploy_swfs(juju)
 
     juju.wait(
-        lambda s: jubilant.all_active(s, "prometheus", "loki", "grafana", "minio", "s3", "otelcol"),
+        lambda s: jubilant.all_active(s, "prometheus", "loki", "grafana", "swfs", "otelcol"),
         timeout=1000,
     )
 
-    juju.integrate("mimir:s3", "s3")
+    juju.integrate("mimir:s3", "swfs")
     juju.wait(lambda s: jubilant.all_blocked(s, "mimir"), timeout=1000)
 
 
@@ -99,7 +87,7 @@ def test_integrate(juju: jubilant.Juju):
     juju.wait(
         lambda s: jubilant.all_active(
             s, "mimir", "prometheus", "loki", "grafana", "otelcol",
-            "minio", "s3", "worker-read", "worker-write", "worker-backend", "traefik",
+            "swfs", "worker-read", "worker-write", "worker-backend", "traefik",
         ),
         timeout=2000,
     )

--- a/tests/integration/test_charm_ha_roles.py
+++ b/tests/integration/test_charm_ha_roles.py
@@ -10,8 +10,7 @@ import jubilant
 import pytest
 from helpers import (
     charm_resources,
-    configure_minio,
-    configure_s3_integrator,
+    deploy_swfs,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,22 +34,11 @@ WORKER_APPS = [f"worker-{role}" for role in ROLES]
 def test_build_and_deploy(juju: jubilant.Juju, mimir_charm: str, cos_channel):
     """Build the charm-under-test and deploy it together with related charms."""
     juju.deploy(mimir_charm, "mimir", resources=charm_resources(), trust=True)
-    # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
-    juju.deploy(
-        "minio",
-        channel="ckf-1.9/stable",
-        config={"access-key": "access", "secret-key": "secretsecret"},
-    )
-    juju.deploy("s3-integrator", "s3", channel="latest/stable")
+    deploy_swfs(juju)
 
-    juju.wait(lambda s: jubilant.all_active(s, "minio"), timeout=1000)
-    juju.wait(lambda s: jubilant.all_blocked(s, "s3"), timeout=1000)
-    configure_minio(juju)
-    configure_s3_integrator(juju)
+    juju.wait(lambda s: jubilant.all_active(s, "swfs"), timeout=1000)
 
-    juju.wait(lambda s: jubilant.all_active(s, "minio", "s3"), timeout=1000)
-
-    juju.integrate("mimir:s3", "s3")
+    juju.integrate("mimir:s3", "swfs")
     juju.wait(lambda s: jubilant.all_blocked(s, "mimir"), timeout=1000)
 
 
@@ -73,6 +61,6 @@ def test_integrate(juju: jubilant.Juju):
         juju.integrate("mimir:mimir-cluster", app)
 
     juju.wait(
-        lambda s: jubilant.all_active(s, "mimir", "minio", "s3", *WORKER_APPS),
+        lambda s: jubilant.all_active(s, "mimir", "swfs", *WORKER_APPS),
         timeout=2000,
     )

--- a/tests/integration/test_charm_ha_scaled.py
+++ b/tests/integration/test_charm_ha_scaled.py
@@ -11,8 +11,7 @@ import pytest
 import requests
 from helpers import (
     charm_resources,
-    configure_minio,
-    configure_s3_integrator,
+    deploy_swfs,
     get_grafana_datasources_from_client_localhost,
     get_mimir_rules_from_grafana,
     get_prometheus_targets_from_client_localhost,
@@ -40,25 +39,14 @@ def test_build_and_deploy(juju: jubilant.Juju, mimir_charm: str, cos_channel):
     juju.deploy("grafana-k8s", "grafana", channel=cos_channel, trust=True)
     juju.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True)
     juju.deploy("opentelemetry-collector-k8s", "otelcol", trust=True, channel=cos_channel)
-    # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
-    juju.deploy(
-        "minio",
-        channel="ckf-1.9/stable",
-        config={"access-key": "access", "secret-key": "secretsecret"},
-    )
-    juju.deploy("s3-integrator", "s3", channel="latest/stable")
-
-    juju.wait(lambda s: jubilant.all_active(s, "minio"), timeout=1000)
-    juju.wait(lambda s: jubilant.all_blocked(s, "s3"), timeout=1000)
-    configure_minio(juju)
-    configure_s3_integrator(juju)
+    deploy_swfs(juju)
 
     juju.wait(
-        lambda s: jubilant.all_active(s, "prometheus", "loki", "grafana", "minio", "s3", "otelcol"),
+        lambda s: jubilant.all_active(s, "prometheus", "loki", "grafana", "swfs", "otelcol"),
         timeout=1000,
     )
 
-    juju.integrate("mimir:s3", "s3")
+    juju.integrate("mimir:s3", "swfs")
     juju.wait(lambda s: jubilant.all_blocked(s, "mimir"), timeout=1000)
 
 
@@ -109,7 +97,7 @@ def test_integrate(juju: jubilant.Juju):
     juju.wait(
         lambda s: jubilant.all_active(
             s, "mimir", "prometheus", "loki", "grafana", "otelcol",
-            "minio", "s3", "worker-read", "worker-write", "worker-backend", "traefik",
+            "swfs", "worker-read", "worker-write", "worker-backend", "traefik",
         ),
         timeout=2000,
     )

--- a/tests/integration/test_charm_ha_scaled_no_traefik.py
+++ b/tests/integration/test_charm_ha_scaled_no_traefik.py
@@ -12,8 +12,7 @@ import jubilant
 import pytest
 from helpers import (
     charm_resources,
-    configure_minio,
-    configure_s3_integrator,
+    deploy_swfs,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,25 +29,14 @@ def test_build_and_deploy(juju: jubilant.Juju, mimir_charm: str, cos_channel):
         trust=True,
     )
     juju.deploy("opentelemetry-collector-k8s", "otelcol", trust=True, channel=cos_channel)
-    # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
-    juju.deploy(
-        "minio",
-        channel="ckf-1.9/stable",
-        config={"access-key": "access", "secret-key": "secretsecret"},
-    )
-    juju.deploy("s3-integrator", "s3", channel="latest/stable")
-
-    juju.wait(lambda s: jubilant.all_active(s, "minio"), timeout=1000)
-    juju.wait(lambda s: jubilant.all_blocked(s, "s3"), timeout=1000)
-    configure_minio(juju)
-    configure_s3_integrator(juju)
+    deploy_swfs(juju)
 
     juju.wait(
-        lambda s: jubilant.all_active(s, "minio", "s3", "otelcol"),
+        lambda s: jubilant.all_active(s, "swfs", "otelcol"),
         timeout=1000,
     )
 
-    juju.integrate("mimir:s3", "s3")
+    juju.integrate("mimir:s3", "swfs")
     juju.wait(lambda s: jubilant.all_blocked(s, "mimir"), timeout=1000)
 
 
@@ -92,7 +80,7 @@ def test_integrate(juju: jubilant.Juju):
 
     juju.wait(
         lambda s: jubilant.all_active(
-            s, "mimir", "minio", "s3",
+            s, "mimir", "swfs",
             "worker-read", "worker-write", "worker-backend",
         ),
         timeout=2000,

--- a/tests/integration/test_charm_monolithic.py
+++ b/tests/integration/test_charm_monolithic.py
@@ -11,8 +11,7 @@ import pytest
 import requests
 from helpers import (
     charm_resources,
-    configure_minio,
-    configure_s3_integrator,
+    deploy_swfs,
     get_grafana_datasources_from_client_localhost,
     get_mimir_rules_from_grafana,
     get_prometheus_targets_from_client_localhost,
@@ -33,28 +32,17 @@ def test_build_and_deploy(juju: jubilant.Juju, mimir_charm: str, cos_channel):
     juju.deploy("grafana-k8s", "grafana", channel=cos_channel, trust=True)
     juju.deploy("traefik-k8s", "traefik", channel="latest/edge", trust=True)
     juju.deploy("opentelemetry-collector-k8s", "otelcol", trust=True, channel=cos_channel)
-    # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
-    juju.deploy(
-        "minio",
-        channel="ckf-1.9/stable",
-        config={"access-key": "access", "secret-key": "secretsecret"},
-    )
-    juju.deploy("s3-integrator", "s3", channel="latest/stable")
-
-    juju.wait(lambda s: jubilant.all_active(s, "minio"), timeout=1000)
-    juju.wait(lambda s: jubilant.all_blocked(s, "s3"), timeout=1000)
-    configure_minio(juju)
-    configure_s3_integrator(juju)
+    deploy_swfs(juju)
 
     juju.wait(
-        lambda s: jubilant.all_active(s, "prometheus", "loki", "grafana", "minio", "s3", "otelcol"),
+        lambda s: jubilant.all_active(s, "prometheus", "loki", "grafana", "swfs", "otelcol"),
         timeout=1000,
     )
 
     # Integrate S3 early so the coordinator has storage config before workers join.
     # This avoids a race where workers read an empty cluster databag because
     # the coordinator's can_handle_events requires s3_ready.
-    juju.integrate("mimir:s3", "s3")
+    juju.integrate("mimir:s3", "swfs")
     juju.wait(lambda s: jubilant.all_blocked(s, "mimir"), timeout=1000)
 
 
@@ -83,7 +71,7 @@ def test_integrate(juju: jubilant.Juju):
     juju.wait(
         lambda s: jubilant.all_active(
             s, "mimir", "prometheus", "loki", "grafana", "otelcol",
-            "minio", "s3", "worker", "traefik",
+            "swfs", "worker", "traefik",
         ),
         timeout=2000,
     )

--- a/tests/integration/test_juju_doctor.py
+++ b/tests/integration/test_juju_doctor.py
@@ -1,6 +1,6 @@
 import pytest
 import sh
-from helpers import charm_resources, configure_minio, configure_s3_integrator
+from helpers import charm_resources, deploy_swfs
 from jubilant import Juju, all_active, all_blocked
 
 
@@ -29,20 +29,11 @@ def test_deploy_workers(juju: Juju, cos_channel):
     )
 
 
-def test_all_active_when_coordinator_and_s3_added(juju: Juju, mimir_charm):
+def test_all_active_when_coordinator_and_swfs_added(juju: Juju, mimir_charm):
     # GIVEN a model with workers
 
     # WHEN deploying and integrating the minimal mimir cluster
-    juju.deploy(
-        "minio",
-        channel="ckf-1.9/stable",
-        config={"access-key": "access", "secret-key": "secretsecret"},
-    )
-    juju.deploy("s3-integrator", "s3", channel="latest/stable")
-    juju.wait(lambda status: all_active(status, "minio"), timeout=1000)
-    juju.wait(lambda status: all_blocked(status, "s3"), timeout=1000)
-    configure_minio(juju)
-    configure_s3_integrator(juju)
+    deploy_swfs(juju)
 
     juju.deploy(
         mimir_charm,
@@ -50,7 +41,7 @@ def test_all_active_when_coordinator_and_s3_added(juju: Juju, mimir_charm):
         resources=charm_resources(),
         trust=True,
     )
-    juju.integrate("mimir:s3", "s3")
+    juju.integrate("mimir:s3", "swfs")
     juju.integrate("mimir:mimir-cluster", "read")
     juju.integrate("mimir:mimir-cluster", "write")
     juju.integrate("mimir:mimir-cluster", "backend")

--- a/tests/integration/test_service_mesh.py
+++ b/tests/integration/test_service_mesh.py
@@ -11,8 +11,7 @@ import pytest
 import requests
 from helpers import (
     charm_resources,
-    configure_minio,
-    configure_s3_integrator,
+    deploy_swfs,
     get_grafana_datasources_from_client_pod,
     get_istio_ingress_ip,
     get_prometheus_targets_from_client_pod,
@@ -33,29 +32,17 @@ def test_build_and_deploy(juju: jubilant.Juju, mimir_charm: str, cos_channel, me
     juju.deploy("istio-k8s", "istio", channel=mesh_channel, trust=True)
     juju.deploy("istio-beacon-k8s", "istio-beacon", channel=mesh_channel, trust=True)
     juju.deploy("istio-ingress-k8s", "istio-ingress", channel=mesh_channel, trust=True)
-    # Secret must be at least 8 characters: https://github.com/canonical/minio-operator/issues/137
-    juju.deploy(
-        "minio",
-        channel="ckf-1.9/stable",
-        config={"access-key": "access", "secret-key": "secretsecret"},
-        trust=True,
-    )
-    juju.deploy("s3-integrator", "s3", channel="latest/stable", trust=True)
-
-    juju.wait(lambda s: jubilant.all_active(s, "minio"), timeout=1000)
-    juju.wait(lambda s: jubilant.all_blocked(s, "s3"), timeout=1000)
-    configure_minio(juju)
-    configure_s3_integrator(juju)
+    deploy_swfs(juju)
 
     juju.wait(
         lambda s: jubilant.all_active(
-            s, "prometheus", "grafana", "minio", "s3",
+            s, "prometheus", "grafana", "swfs",
             "istio", "istio-beacon", "istio-ingress", "otelcol",
         ),
         timeout=1000,
     )
 
-    juju.integrate("mimir:s3", "s3")
+    juju.integrate("mimir:s3", "swfs")
     juju.wait(lambda s: jubilant.all_blocked(s, "mimir"), timeout=1000)
 
 
@@ -93,7 +80,7 @@ def test_integrate(juju: jubilant.Juju):
     juju.wait(
         lambda s: jubilant.all_active(
             s, "mimir", "prometheus", "grafana", "otelcol",
-            "minio", "s3", "worker", "istio-ingress",
+            "swfs", "worker", "istio-ingress",
         ),
         timeout=1000,
         successes=10,

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -20,7 +20,6 @@ dev = [
     "pytest",
     "coverage[toml]",
     # Integration
-    "minio",
     "tenacity",
     "juju",
     "pytest"

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -25,39 +25,6 @@ wheels = [
 ]
 
 [[package]]
-name = "argon2-cffi"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "argon2-cffi-bindings" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
-]
-
-[[package]]
-name = "argon2-cffi-bindings"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cffi" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
-    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
-    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
-    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
-    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
-]
-
-[[package]]
 name = "backports-datetime-fromisoformat"
 version = "2.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -586,7 +553,6 @@ dev = [
     { name = "codespell" },
     { name = "coverage" },
     { name = "juju" },
-    { name = "minio" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
@@ -601,29 +567,12 @@ requires-dist = [
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "juju", marker = "extra == 'dev'" },
     { name = "lightkube-extensions" },
-    { name = "minio", marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "tenacity", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]
-
-[[package]]
-name = "minio"
-version = "7.2.20"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "argon2-cffi" },
-    { name = "certifi" },
-    { name = "pycryptodome" },
-    { name = "typing-extensions" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/40/df/6dfc6540f96a74125a11653cce717603fd5b7d0001a8e847b3e54e72d238/minio-7.2.20.tar.gz", hash = "sha256:95898b7a023fbbfde375985aa77e2cd6a0762268db79cf886f002a9ea8e68598", size = 136113, upload-time = "2025-11-27T00:37:15.569Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/9a/b697530a882588a84db616580f2ba5d1d515c815e11c30d219145afeec87/minio-7.2.20-py3-none-any.whl", hash = "sha256:eb33dd2fb80e04c3726a76b13241c6be3c4c46f8d81e1d58e757786f6501897e", size = 93751, upload-time = "2025-11-27T00:37:13.993Z" },
-]
 
 [[package]]
 name = "mypy-extensions"
@@ -802,25 +751,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
-]
-
-[[package]]
-name = "pycryptodome"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
-    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
-    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
-    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
-    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
-    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Replaces Minio and the S3 Integrator with Seaweedfs from channel `latest/edge`.


## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
