### PR TITLE
fix: update docs link

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -30,7 +30,7 @@ description: |
   - Distributed tracing support via integration with Tempo.
 
 links:
-  documentation: https://discourse.charmhub.io/t/mimir-coordinator-index/10531
+  documentation: https://documentation.ubuntu.com/observability/latest
   website: https://charmhub.io/mimir-coordinator-k8s
   source: https://github.com/canonical/mimir-coordinator-k8s-operator
   issues: https://github.com/canonical/mimir-coordinator-k8s-operator/issues

--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -24,7 +24,7 @@ description: |
   - Persistent storage for data and recovery across container restarts.
 
 links:
-  documentation: https://discourse.charmhub.io/t/mimir-worker-k8s-index/13464
+  documentation: https://documentation.ubuntu.com/observability/latest
   website: https://charmhub.io/mimir-worker-k8s
   source: https://github.com/canonical/mimir-worker-k8s-operator
   issues: https://github.com/canonical/mimir-worker-k8s-operator/issues


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The documentation link for both the worker and coordinator should point to the stack docs. The relevant materials from Discourse have already been migrated to Sphinx.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
