### PR TITLE
fix: sort grpc addresses to avoid unnecessary worker restarts

### DIFF
--- a/coordinator/src/mimir_config.py
+++ b/coordinator/src/mimir_config.py
@@ -203,10 +203,7 @@ class MimirConfig:
         }
 
     def _get_grpc_addresses(self, cluster: ClusterProvider, role: str) -> List[str]:
-        """Extract gRPC addresses (host:port) for a given role from the cluster.
-
-        We return a sorted list to avoid issues such as: https://github.com/canonical/cos-coordinated-workers/issues/158.
-        """
+        """Extract gRPC addresses (host:port) for a given role from the cluster."""
         addresses = cluster.gather_addresses_by_role().get(role, [])
         grpc_addresses = []
         for addr in addresses:

--- a/coordinator/src/mimir_config.py
+++ b/coordinator/src/mimir_config.py
@@ -203,7 +203,10 @@ class MimirConfig:
         }
 
     def _get_grpc_addresses(self, cluster: ClusterProvider, role: str) -> List[str]:
-        """Extract gRPC addresses (host:port) for a given role from the cluster."""
+        """Extract gRPC addresses (host:port) for a given role from the cluster.
+
+        We return a sorted list to avoid issues such as: https://github.com/canonical/cos-coordinated-workers/issues/158.
+        """
         addresses = cluster.gather_addresses_by_role().get(role, [])
         grpc_addresses = []
         for addr in addresses:
@@ -216,7 +219,7 @@ class MimirConfig:
                 hostname = addr.split(":")[0]
             if hostname:
                 grpc_addresses.append(f"{hostname}:{MIMIR_GRPC_LISTEN_PORT}")
-        return grpc_addresses
+        return sorted(grpc_addresses)
 
     # scheduler_address:
     # Address of the query-scheduler component, in host:port format.

--- a/coordinator/tests/unit/test_mimir_config.py
+++ b/coordinator/tests/unit/test_mimir_config.py
@@ -108,6 +108,28 @@ def test_build_compactor_config(mimir_config):
     assert compactor_config == expected_config
 
 
+def test_get_grpc_addresses_returns_sorted_addresses(mimir_config, coordinator):
+    # GIVEN the coordinated workers' cluster interface returns the query-scheduler units' addresses in a non-deterministic order
+    coordinator.cluster.gather_addresses_by_role.return_value = {
+        "query-scheduler": [
+            "http://mimir-2.mimir-endpoints.model.svc.cluster.local:8080",
+            "http://mimir-0.mimir-endpoints.model.svc.cluster.local:8080",
+            "http://mimir-1.mimir-endpoints.model.svc.cluster.local:8080",
+        ]
+    }
+
+    # WHEN we call the _get_grpc_addresses method for the query-scheduler role
+    grpc_addresses = mimir_config._get_grpc_addresses(coordinator.cluster, "query-scheduler")
+
+    # THEN we should get back a sorted list of gRPC addresses (host:port) for the query-scheduler units
+    # Note that the port should be transformed from 8080 (HTTP) to 9095 (gRPC) in the output
+    assert grpc_addresses == [
+        "mimir-0.mimir-endpoints.model.svc.cluster.local:9095",
+        "mimir-1.mimir-endpoints.model.svc.cluster.local:9095",
+        "mimir-2.mimir-endpoints.model.svc.cluster.local:9095",
+    ]
+
+
 @pytest.mark.parametrize(
     "addresses_by_role, expected_config",
     [

--- a/coordinator/tests/unit/test_mimir_config.py
+++ b/coordinator/tests/unit/test_mimir_config.py
@@ -109,6 +109,7 @@ def test_build_compactor_config(mimir_config):
 
 
 def test_get_grpc_addresses_returns_sorted_addresses(mimir_config, coordinator):
+    # We ensure that we return a sorted list to avoid issues such as: https://github.com/canonical/cos-coordinated-workers/issues/158.
     # GIVEN the coordinated workers' cluster interface returns the query-scheduler units' addresses in a non-deterministic order
     coordinator.cluster.gather_addresses_by_role.return_value = {
         "query-scheduler": [


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Related to https://github.com/canonical/cos-coordinated-workers/issues/158.
The proposed fix in the issue recommends updating the logic in the coordinator worker lib to return a sorted list, but it is less of an effort (and a more localized, efficient fix) to implement the fix closer to the caller, rather than have it propagate all the way down from CW.
## Solution
<!-- A summary of the solution addressing the above issue -->
We sort the list of addresses returned by `MimirConfig._get_grpc_addresses` to avoid unnecessary restarts of the worker in case the query-scheduler changed due to a change in orders.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
