### PR TITLE
fix: correct Prometheus alerts path

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -222,7 +222,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
     def _catalogue_item(self) -> CatalogueItem:
         api_endpoints = {
             "Prometheus rules": "/prometheus/api/v1/rules",
-            "Active alerts": "/promtheus/api/v1/alerts",
+            "Active alerts": "/prometheus/api/v1/alerts",
             "Query": "/prometheus/api/v1/query",
             "Push": "/api/v1/push",
             "OTLP metrics": "/otlp/v1/metrics",


### PR DESCRIPTION
## Summary

Fixes a typo in the Mimir coordinator catalogue endpoint for active alerts.

## Changes
- Corrects `/promtheus/api/v1/alerts` to `/prometheus/api/v1/alerts`

## Testing
- Not run; one-line URL typo fix only.