### PR TITLE
chore: bump coordinated workers

### DIFF
--- a/coordinator/pyproject.toml
+++ b/coordinator/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.0"
 requires-python = "~=3.14.0"
 
 dependencies = [
-  "coordinated-workers@ git+https://github.com/canonical/cos-coordinated-workers.git@chore/bump-charmlibs-nginx",
+  "coordinated-workers>=4.1.0",
   "charmed-service-mesh-helpers>=0.2.0",
   "lightkube-extensions",
 ]

--- a/coordinator/pyproject.toml
+++ b/coordinator/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.0"
 requires-python = "~=3.14.0"
 
 dependencies = [
-  "coordinated-workers>=4",
+  "coordinated-workers@ git+https://github.com/canonical/cos-coordinated-workers.git@chore/bump-charmlibs-nginx",
   "charmed-service-mesh-helpers>=0.2.0",
   "lightkube-extensions",
 ]

--- a/coordinator/uv.lock
+++ b/coordinator/uv.lock
@@ -186,11 +186,15 @@ wheels = [
 
 [[package]]
 name = "charmlibs-nginx-k8s"
-version = "1.0.0"
-source = { git = "https://github.com/sinapah/charmlibs.git?subdirectory=nginx_k8s&rev=feat%2Fnginx-exporter-configure-tls#62ca83703318813828b76654fa3e79c8006044eb" }
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "crossplane" },
     { name = "ops" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/64/4712bd0fbeda002361ef7b5e74bbf695004a29d6f3957d436ab06648b15f/charmlibs_nginx_k8s-1.0.1.tar.gz", hash = "sha256:9dcfeb52b9dbee77d66ab90ee86117d7494889325a2961fc7c55109b3d8dbbe9", size = 38679, upload-time = "2026-06-22T15:23:12.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/1c/ef9ff46a5cb167ec917a86cfbdcb7bc2a98a8a767efa672bc30920b78dc6/charmlibs_nginx_k8s-1.0.1-py3-none-any.whl", hash = "sha256:8e5246e26aaa6ac749f8cd82db5a1dd30535612961afc7597c75933122c02638", size = 18177, upload-time = "2026-06-22T15:23:11.52Z" },
 ]
 
 [[package]]
@@ -266,8 +270,8 @@ wheels = [
 
 [[package]]
 name = "coordinated-workers"
-version = "4.0.1"
-source = { git = "https://github.com/canonical/cos-coordinated-workers.git?rev=chore%2Fbump-charmlibs-nginx#86392086ae76463081403534dfc0206fb4efcfa8" }
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "charmed-service-mesh-helpers" },
     { name = "charmlibs-interfaces-tls-certificates" },
@@ -278,6 +282,10 @@ dependencies = [
     { name = "lightkube-extensions" },
     { name = "ops", extra = ["tracing"] },
     { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/0f/4eb6682434382c734bf70821efacbb48932e5b847227669d89fe7e4a2bb9/coordinated_workers-4.1.0.tar.gz", hash = "sha256:5218b4aa0dc78a3b3abaaab9bcb35adc4140efdaf92f06fb0fcaf10eaa707125", size = 380170, upload-time = "2026-06-23T15:11:59.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/24/7826b9d84b1e5b7d2eeb4381cc0d1c3e7163fdf93efde559997fa2bfa17b/coordinated_workers-4.1.0-py3-none-any.whl", hash = "sha256:4e4779017f33dfdef647302dd10a106893c7c7a04941bf7cb934a8495dd43279", size = 48530, upload-time = "2026-06-23T15:11:58.21Z" },
 ]
 
 [[package]]
@@ -747,7 +755,7 @@ dev = [
 requires-dist = [
     { name = "charmed-service-mesh-helpers", specifier = ">=0.2.0" },
     { name = "codespell", marker = "extra == 'dev'" },
-    { name = "coordinated-workers", git = "https://github.com/canonical/cos-coordinated-workers.git?rev=chore%2Fbump-charmlibs-nginx" },
+    { name = "coordinated-workers", specifier = ">=4.1.0" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "deepdiff", marker = "extra == 'dev'" },
     { name = "jubilant", marker = "extra == 'dev'" },

--- a/coordinator/uv.lock
+++ b/coordinator/uv.lock
@@ -186,15 +186,11 @@ wheels = [
 
 [[package]]
 name = "charmlibs-nginx-k8s"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
+version = "1.0.0"
+source = { git = "https://github.com/sinapah/charmlibs.git?subdirectory=nginx_k8s&rev=feat%2Fnginx-exporter-configure-tls#62ca83703318813828b76654fa3e79c8006044eb" }
 dependencies = [
     { name = "crossplane" },
     { name = "ops" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/1aacb27aa6b8cce0dbb30bba56e79336683ac981682bb761edab1d378f78/charmlibs_nginx_k8s-0.1.0.tar.gz", hash = "sha256:6e1486289546d5ee8f108aae01e886728c27aa556e1a18d0a57ab84aab4e4ab1", size = 36645, upload-time = "2025-12-15T09:38:22.362Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/51/eb217b37f1907a19768abaf65b598a0ac2cceb12dcca087c09c7fbd716c8/charmlibs_nginx_k8s-0.1.0-py3-none-any.whl", hash = "sha256:3ea564cf2ca052234ba75578060af4c2246d6cf0f4936dfe767f19f922bc289d", size = 17348, upload-time = "2025-12-15T09:38:20.946Z" },
 ]
 
 [[package]]
@@ -271,7 +267,7 @@ wheels = [
 [[package]]
 name = "coordinated-workers"
 version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/canonical/cos-coordinated-workers.git?rev=chore%2Fbump-charmlibs-nginx#86392086ae76463081403534dfc0206fb4efcfa8" }
 dependencies = [
     { name = "charmed-service-mesh-helpers" },
     { name = "charmlibs-interfaces-tls-certificates" },
@@ -282,10 +278,6 @@ dependencies = [
     { name = "lightkube-extensions" },
     { name = "ops", extra = ["tracing"] },
     { name = "pydantic" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/d0/6b6921e1fbb1e1a1539c37308683c6c1dea110419d3de45a945f3a7549c4/coordinated_workers-4.0.1.tar.gz", hash = "sha256:dc19d73285b6164e909bfad528ef18e5542fe0d092395101cc19189d6160b2fc", size = 379113, upload-time = "2026-04-30T16:11:40.949Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/3e/5ed2f4a4b9abb995d49a03bee9eca92263240edddf4ec5554ca8a2bc0721/coordinated_workers-4.0.1-py3-none-any.whl", hash = "sha256:9f753274a65a31874ea2c4ece7fd547209406aafed5f8748ab96f197d751c03d", size = 48498, upload-time = "2026-04-30T16:11:39.215Z" },
 ]
 
 [[package]]
@@ -755,7 +747,7 @@ dev = [
 requires-dist = [
     { name = "charmed-service-mesh-helpers", specifier = ">=0.2.0" },
     { name = "codespell", marker = "extra == 'dev'" },
-    { name = "coordinated-workers", specifier = ">=4" },
+    { name = "coordinated-workers", git = "https://github.com/canonical/cos-coordinated-workers.git?rev=chore%2Fbump-charmlibs-nginx" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "deepdiff", marker = "extra == 'dev'" },
     { name = "jubilant", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Must be merged after https://github.com/canonical/cos-coordinated-workers/pull/163 is merged.
Related to: https://github.com/canonical/charmlibs/pull/539.

This ensures that we are able to correctly remote write and scrape Nginx Prometheus Exporter metrics.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
