### PR TITLE
fix: mimirtool TLS failure, stale hash on exec error, and missing leader guard

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -343,7 +343,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
                 if stdout:
                     logger.info("mimirtool: %s", stdout.strip())
                 if stderr:
-                    logger.warning("mimirtool (stderr): %s", stderr.strip())
+                    logger.warning("mimirtool: %s", stderr.strip())
                 self._push(ALERTS_HASH_PATH, alerts_hash)
             except ExecError as e:
                 logger.error("mimirtool rules sync failed (exit %d): %s", e.exit_code, e.stderr)

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -36,6 +36,7 @@ from cosl.time_validation import is_valid_timespec
 from ops import ActiveStatus, BlockedStatus
 from ops.model import ModelError
 from ops.pebble import Error as PebbleError
+from ops.pebble import ExecError
 
 from mimir_config import MIMIR_ROLES_CONFIG, MimirConfig
 from nginx_config import NginxHelper
@@ -304,6 +305,9 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
 
         Assumes the nginx container can connect.
         """
+        if not self.unit.is_leader():
+            return
+
         # Get mimirtool if this is the first execution
         self._ensure_mimirtool()
 
@@ -321,23 +325,28 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
             # Update the alert rules files on disk
             self._nginx_container.remove_path(RULES_DIR, recursive=True)
             rules_file_paths: List[str] = self._push_alert_rules(remote_write_alerts)
-            self._push(ALERTS_HASH_PATH, alerts_hash)
-            # Push the alert rules to the Mimir cluster (persisted in s3)
-            mimirtool_output = self._nginx_container.pebble.exec(
-                [
-                    "mimirtool",
-                    "rules",
-                    "sync",
-                    *rules_file_paths,
-                    f"--address={self.most_external_url}",
-                    "--id=anonymous",  # multitenancy is disabled, the default tenant is 'anonymous'
-                ],
-                encoding="utf-8",
-            )
-            if mimirtool_output.stdout:
-                logger.info(f"mimirtool: {mimirtool_output.stdout.read().strip()}")
-            if mimirtool_output.stderr:
-                logger.error(f"mimirtool (err): {mimirtool_output.stderr.read().strip()}")
+            # Push the alert rules to the Mimir cluster (persisted in s3).
+            # The hash is only written after a successful sync so that a failed
+            # mimirtool invocation is retried on the next hook run.
+            try:
+                stdout, stderr = self._nginx_container.pebble.exec(
+                    [
+                        "mimirtool",
+                        "rules",
+                        "sync",
+                        *rules_file_paths,
+                        f"--address={self.internal_url}",
+                        "--id=anonymous",  # multitenancy is disabled, the default tenant is 'anonymous'
+                    ],
+                    encoding="utf-8",
+                ).wait_output()
+                if stdout:
+                    logger.info("mimirtool: %s", stdout.strip())
+                if stderr:
+                    logger.warning("mimirtool (stderr): %s", stderr.strip())
+                self._push(ALERTS_HASH_PATH, alerts_hash)
+            except ExecError as e:
+                logger.error("mimirtool rules sync failed (exit %d): %s", e.exit_code, e.stderr)
 
     def _update_prometheus_api(self) -> None:
         """Update all applications related to us via the prometheus-api relation."""

--- a/coordinator/tests/unit/test_charm.py
+++ b/coordinator/tests/unit/test_charm.py
@@ -1,3 +1,4 @@
+import socket
 from typing import Union
 from unittest.mock import MagicMock, patch
 
@@ -6,7 +7,6 @@ from coordinated_workers.coordinator import Coordinator
 from helpers import get_key_from_worker_config_exemplars
 from ops.testing import ActiveStatus, BlockedStatus
 from scenario import Container, Exec, State
-    import socket
 
 from charm import ALERTS_HASH_PATH, NGINX_PORT
 from src.mimir_config import (
@@ -138,7 +138,6 @@ def test_alerts_hash_not_written_on_mimirtool_failure(
     would see "no change" and silently skip the sync, leaving Mimir without
     the updated alert rules indefinitely.
     """
-
     address_arg = f"--address=http://{socket.getfqdn()}:{NGINX_PORT}"
     failing_container = Container(
         "nginx",

--- a/coordinator/tests/unit/test_charm.py
+++ b/coordinator/tests/unit/test_charm.py
@@ -5,8 +5,10 @@ import pytest as pytest
 from coordinated_workers.coordinator import Coordinator
 from helpers import get_key_from_worker_config_exemplars
 from ops.testing import ActiveStatus, BlockedStatus
-from scenario import State
+from scenario import Container, Exec, State
+    import socket
 
+from charm import ALERTS_HASH_PATH, NGINX_PORT
 from src.mimir_config import (
     MIMIR_ROLES_CONFIG,
     MINIMAL_DEPLOYMENT,
@@ -122,3 +124,43 @@ def test_config_retention_period(context, s3, all_worker, nginx_container, nginx
         config = get_key_from_worker_config_exemplars(state_out.relations, "mimir-cluster", "compactor_blocks_retention_period")
         assert config == expected_value
         assert isinstance(state_out.unit_status, expected_status)
+
+
+def test_alerts_hash_not_written_on_mimirtool_failure(
+    context,
+    s3,
+    all_worker,
+    nginx_prometheus_exporter_container,
+):
+    """The alerts hash must NOT be persisted when mimirtool exits non-zero.
+
+    If the hash were written before confirming success, subsequent hook runs
+    would see "no change" and silently skip the sync, leaving Mimir without
+    the updated alert rules indefinitely.
+    """
+
+    address_arg = f"--address=http://{socket.getfqdn()}:{NGINX_PORT}"
+    failing_container = Container(
+        "nginx",
+        can_connect=True,
+        execs={
+            Exec(
+                ["mimirtool", "rules", "sync", address_arg, "--id=anonymous"],
+                return_code=1,
+            ),
+            Exec(["update-ca-certificates", "--fresh"], return_code=0),
+        },
+    )
+
+    state_in = State(
+        relations=[s3, all_worker],
+        containers=[failing_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+
+    with context(context.on.relation_changed(all_worker), state_in) as mgr:
+        state_out = mgr.run()
+
+    # THEN the hash file is absent so the next hook run retries the sync
+    nginx_fs = state_out.get_container("nginx").get_filesystem(context)
+    assert not (nginx_fs / ALERTS_HASH_PATH.lstrip("/")).exists()


### PR DESCRIPTION
Fixes #116 and a bunch of other things

## Issue

1. TLS verification failure with Traefik ingress

`_set_alerts` used the ingressed url as `--address` to mimirtool rules sync. When traefik is behind TLS, mimirtool has no knowledge of Traefik's CA, causing an x509 verification failure and preventing alert rules from ever reaching Mimir.

2. Hash written before sync

The alerts hash was persisted to disk before calling mimirtool. If mimirtool failed for any reason (TLS error, Mimir unreachable, etc.), the hash was already updated. Every subsequent hook run saw "no change" and skipped the sync entirely, silently leaving the Mimir cluster without the correct alert rules.

The original code also never called .wait() on the exec process, so the return code was never checked and the process may not have finished before stdout/stderr were read.

3. Missing leader guard

_set_alerts is a leader concern according to https://github.com/canonical/prometheus-k8s-operator/blob/375ed61d8629b235a60dae7f2b9220d5846b0370/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py#L841

## Solution
1. Use internal_url for the mimirtool address

When the coordinator itself uses TLS, internal_url switches to https://fqdn:443. There is no server-name mismatch (nginx's cert is issued for socket.getfqdn()) 

2. Write the hash only after a confirmed successful sync

3. Add leader guard to _set_alerts

