### PR TITLE
fix(coordinator): trust Mimir's CA when syncing rules over TLS

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -342,6 +342,28 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
             with open("mimirtool", "rb") as f:
                 self._nginx_container.push("/usr/bin/mimirtool", source=f, permissions=0o744)
 
+    def _rules_sync_command(self, rules_file_paths: List[str]) -> List[str]:
+        """Build the ``mimirtool rules sync`` command.
+
+        When Mimir is served over TLS, ``mimirtool`` must be told which CA to trust;
+        otherwise ``rules sync`` fails certificate verification against Mimir's
+        (internally-issued) certificate and alert rules are never loaded. The CA bundle is
+        guaranteed to be on disk whenever ``internal_url`` is https (see ``are_certificates_on_disk``).
+
+        See https://github.com/canonical/opentelemetry-collector-operator/issues/328
+        """
+        command = [
+            "mimirtool",
+            "rules",
+            "sync",
+            *rules_file_paths,
+            f"--address={self.internal_url}",
+            "--id=anonymous",  # multitenancy is disabled, the default tenant is 'anonymous'
+        ]
+        if self.internal_url.startswith("https"):
+            command.append(f"--tls-ca-path={TLSConfigManager.CA_CERT_PATH}")
+        return command
+
     def _set_alerts(self):
         """Create alert rule files for all Mimir consumers.
 
@@ -372,14 +394,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
             # mimirtool invocation is retried on the next hook run.
             try:
                 stdout, stderr = self._nginx_container.pebble.exec(
-                    [
-                        "mimirtool",
-                        "rules",
-                        "sync",
-                        *rules_file_paths,
-                        f"--address={self.internal_url}",
-                        "--id=anonymous",  # multitenancy is disabled, the default tenant is 'anonymous'
-                    ],
+                    self._rules_sync_command(rules_file_paths),
                     encoding="utf-8",
                 ).wait_output()
                 if stdout:

--- a/coordinator/tests/unit/test_tls.py
+++ b/coordinator/tests/unit/test_tls.py
@@ -1,14 +1,14 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import scenario
 from charmlibs.nginx_k8s import Nginx
 from helpers import get_relation_data
 from scenario import Relation, State
 
-from charm import NGINX_PORT, NGINX_TLS_PORT
+from charm import NGINX_PORT, NGINX_TLS_PORT, MimirCoordinatorK8SOperatorCharm
 
 
 def test_ingress_tls(
@@ -53,3 +53,51 @@ def test_ingress_tls(
         # THEN Loki publishes its Nginx TLS port in the ingress databag
         assert get_relation_data(state_out.relations, "ingress", "scheme") == '"https"'
         assert get_relation_data(state_out.relations, "ingress", "port") == str(NGINX_TLS_PORT)
+
+
+def _rules_sync_state(s3, all_worker, nginx_container, nginx_prometheus_exporter_container):
+    return State(
+        relations=[s3, all_worker],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        unit_status=scenario.ActiveStatus(),
+        leader=True,
+    )
+
+
+def test_rules_sync_command_omits_tls_ca_path_over_http(
+    context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+):
+    # GIVEN Mimir is served over HTTP (no certificates on disk)
+    state_in = _rules_sync_state(
+        s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+    )
+    with context(context.on.update_status(), state_in) as mgr:
+        charm = mgr.charm
+        # WHEN the mimirtool rules sync command is built
+        command = charm._rules_sync_command(["/etc/mimir-alerts/rules/example.rules"])
+
+    # THEN the address is http and no TLS CA path is passed
+    assert any(arg.startswith("--address=http://") for arg in command)
+    assert not any(arg.startswith("--tls-ca-path=") for arg in command)
+
+
+def test_rules_sync_command_adds_tls_ca_path_over_https(
+    context, s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+):
+    # GIVEN Mimir is served over HTTPS (the cert is internally-issued; its CA is on disk)
+    state_in = _rules_sync_state(
+        s3, all_worker, nginx_container, nginx_prometheus_exporter_container
+    )
+    with context(context.on.update_status(), state_in) as mgr:
+        charm = mgr.charm
+        with patch.object(
+            MimirCoordinatorK8SOperatorCharm,
+            "internal_url",
+            new_callable=PropertyMock,
+            return_value="https://mimir.test:8080",
+        ):
+            # WHEN the mimirtool rules sync command is built
+            command = charm._rules_sync_command(["/etc/mimir-alerts/rules/example.rules"])
+
+    # THEN mimirtool is told to verify against Mimir's CA bundle (otelcol-operator#328)
+    assert any(arg.startswith("--tls-ca-path=") for arg in command)


### PR DESCRIPTION
## Issue
With Mimir served over TLS, `_set_alerts` runs `mimirtool rules sync` with no TLS option, so it fails
certificate verification (`x509: certificate signed by unknown authority`) and alert rules never load.
Metrics are unaffected. Reported as canonical/opentelemetry-collector-operator#328.

## Solution
Pass `--tls-ca-path=<CA on disk>` when `internal_url` is https, so `mimirtool` verifies Mimir's own
certificate. The CA bundle is guaranteed present whenever `internal_url` is https
(`are_certificates_on_disk`). The command is extracted into a `_rules_sync_command()` helper.

## Testing Instructions
`tox -e unit` — 84 passed, including two new tests in `tests/unit/test_tls.py` (CA path added over
https, omitted over http).

## Note
The issue is filed on `opentelemetry-collector-operator`, but otelcol forwards rules correctly over the
`prometheus_remote_write` relation databag — the failing upload is here. Suggest transferring the issue
to `mimir-operators`.
