### PR TITLE
fix: update charmcraft.yaml metadata (track 2)

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -4,13 +4,35 @@ name: mimir-coordinator-k8s
 type: charm
 summary: Mimir coordinator
 description: |
-  Mimir coordinator.
+  Mimir Coordinator K8s is a Juju charm that manages the configuration, routing, and external
+  integrations for a horizontally scalable Grafana Mimir deployment on Kubernetes. It works
+  together with the Mimir Worker charm, following the coordinated-workers pattern. It is a
+  component of the Canonical Observability Stack (COS):
+  https://documentation.ubuntu.com/observability
+
+  The coordinator handles all external relations - such as metrics ingestion via Prometheus
+  remote write, alerting, Grafana datasources, and dashboards - and distributes the generated
+  Mimir configuration to the worker units. An nginx reverse proxy routes incoming traffic to
+  the appropriate workers based on their assigned roles.
+
+  Key features:
+
+  - Centralized management of all external integrations, including metrics ingestion via `prometheus_remote_write`, visualization and data source integration with Grafana, and alerting through Alertmanager.
+  - Prometheus-compatible API, allowing Mimir to be used as a drop-in long-term storage
+    backend for Prometheus metrics.
+  - Automatic configuration distribution to Mimir Worker units via the mimir-cluster relation.
+  - Built-in nginx reverse proxy for load balancing and traffic routing across workers.
+  - S3-compatible object storage integration for scalable metrics data persistence.
+  - Built-in Grafana dashboards and Prometheus alert rules for self-monitoring.
+  - Configurable metrics retention period and exemplar storage limits.
+  - TLS support via the certificates relation.
+  - Ingress support for external access through reverse proxies such as Traefik.
+  - Distributed tracing support via integration with Tempo.
 
 links:
-  documentation: https://discourse.charmhub.io/t/mimir-coordinator-index/10531
-  website: https://charmhub.io/mimir-coordinator-k8s
-  source: https://github.com/canonical/mimir-coordinator-k8s-operator
-  issues: https://github.com/canonical/mimir-coordinator-k8s-operator/issues
+  documentation: https://documentation.ubuntu.com/observability/track-2
+  source: https://github.com/canonical/mimir-operators
+  issues: https://github.com/canonical/mimir-operators/issues
 
 assumes:
   - k8s-api

--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -4,14 +4,29 @@ name: mimir-worker-k8s
 type: charm
 summary: Mimir for Kubernetes clusters.
 description: |
-  Grafana Mimir is an open source software project that provides a scalable long-term storage for Prometheus.
-  This charm deploys and operates Mimir on Kubernetes clusters
+  Mimir Worker K8s is a Juju charm that runs Grafana Mimir components on Kubernetes as part of
+  a horizontally scalable deployment. It works together with the Mimir Coordinator charm,
+  following the coordinated-workers pattern. It is a component of the Canonical Observability
+  Stack (COS):
+  https://documentation.ubuntu.com/observability
+
+  Each worker unit receives its configuration from the coordinator and executes one or more
+  Mimir roles, enabling flexible scaling of individual components independently.
+
+  Key features:
+
+  - Fine-grained role configuration: individual roles (compactor, distributor, ingester,
+    querier, query-frontend, store-gateway, ruler, alertmanager, query-scheduler,
+    overrides-exporter, flusher) or meta-roles (read, write, backend, all).
+  - Horizontal scaling by adding more worker units with the desired role combination.
+  - Automatic configuration received from the Mimir Coordinator via the mimir-cluster
+    relation.
+  - Persistent storage for data and recovery across container restarts.
 
 links:
-  documentation: https://discourse.charmhub.io/t/mimir-worker-k8s-index/13464
-  website: https://charmhub.io/mimir-worker-k8s
-  source: https://github.com/canonical/mimir-worker-k8s-operator
-  issues: https://github.com/canonical/mimir-worker-k8s-operator/issues
+  documentation: https://documentation.ubuntu.com/observability/track-2
+  source: https://github.com/canonical/mimir-operators
+  issues: https://github.com/canonical/mimir-operators/issues
 
 assumes:
   - k8s-api


### PR DESCRIPTION
This PR updates metadata in line with the `main` branch.

Addresses:
- https://github.com/canonical/charmhub-listing-review/issues/86
- https://github.com/canonical/charmhub-listing-review/issues/87