### PR TITLE
fix: update charmcraft.yaml metadata

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -196,6 +196,7 @@ requires:
   service-mesh:
     limit: 1
     interface: service_mesh
+    optional: true
     description: |
       Subscribe this charm into a service mesh and create authorization policies.
       We forward to the beacon our authorization policies.
@@ -205,6 +206,7 @@ requires:
     # TODO: remove this relation when this is fixed:
     #   https://github.com/canonical/istio-beacon-k8s-operator/issues/91
     interface: cross_model_mesh
+    optional: true
 config:
   options:
     max_global_exemplars_per_user:

--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -31,7 +31,6 @@ description: |
 
 links:
   documentation: https://documentation.ubuntu.com/observability/latest
-  website: https://charmhub.io/mimir-coordinator-k8s
   source: https://github.com/canonical/mimir-coordinator-k8s-operator
   issues: https://github.com/canonical/mimir-coordinator-k8s-operator/issues
 

--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -25,7 +25,6 @@ description: |
 
 links:
   documentation: https://documentation.ubuntu.com/observability/latest
-  website: https://charmhub.io/mimir-worker-k8s
   source: https://github.com/canonical/mimir-worker-k8s-operator
   issues: https://github.com/canonical/mimir-worker-k8s-operator/issues
 


### PR DESCRIPTION
This PR updates metadata in charmcraft.yaml to address:
- https://github.com/canonical/charmhub-listing-review/issues/86
- https://github.com/canonical/charmhub-listing-review/issues/87