### PR TITLE
fix: Add timeInterval to grafana-source relation extra fields - track/2 backport

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -49,6 +49,12 @@ ALERTS_HASH_PATH = "/etc/mimir-alerts/alerts.sha256"
 NGINX_PORT = NginxHelper._port
 NGINX_TLS_PORT = NginxHelper._tls_port
 
+# 60s is expected to be the longest scrape interval in most deployments,
+# so setting timeInterval to it in Grafana when a grafana_source relation is
+# established would guarantee that timestep-sensitive artifacts such as
+# `$__rate_interval` variable and `irate` function would keep working as expected.
+DEFAULT_COS_GLOBAL_SCRAPE_INTERVAL = "60s"
+
 
 class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
     """Charm the service."""

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -419,6 +419,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         metrics_to_traces_config = self._build_metrics_to_traces_config()
 
         return {
+            "timeInterval": DEFAULT_COS_GLOBAL_SCRAPE_INTERVAL,
             "httpHeaderName1": "X-Scope-OrgID",
             **metrics_to_traces_config,
         }

--- a/coordinator/tests/unit/test_grafana_source_extra_fields.py
+++ b/coordinator/tests/unit/test_grafana_source_extra_fields.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+import json
+
+from ops.testing import Relation, State
+
+
+def test_grafana_source_relation_extra_fields(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    # GIVEN a grafana-source relation, s3 and all_worker relations, nginx containers, and the unit is leader
+    grafana_source = Relation("grafana-source", remote_app_name="grafana")
+    state_in = State(
+        relations=[s3, all_worker, grafana_source],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+    # WHEN update_status is triggered
+    state_out = context.run(context.on.update_status(), state_in)
+    gs_data = json.loads(
+        state_out.get_relation(grafana_source.id).local_app_data["grafana_source_data"]
+    )
+    # THEN the grafana-source relation data includes timeInterval=60s and httpHeaderName1
+    # NOTE: OTel collector scrapes every 60s by default. Grafana defaults to 15s if not informed,
+    # causing dashboard errors. This assertion ensures Mimir communicates the correct interval.
+    assert gs_data["extra_fields"]["timeInterval"] == "60s"
+    assert gs_data["extra_fields"]["httpHeaderName1"] == "X-Scope-OrgID"


### PR DESCRIPTION
This PR backports https://github.com/canonical/mimir-operators/pull/121 to track/2

--- 
This PR mitigates errors we see in this issue: https://github.com/canonical/mimir-operators/issues/82 with some Grafana Dashboards

Although it is configurable, by default Opentelemetry Collector scrapes and sends metrics every 60 seconds (which is very common in production to avoid overloading storage).

Mimir now informs this default value to Grafana because if not, it will use `15s` as default, which produces the errors.


### Changes

- **`coordinator/src/charm.py`**: Add `DEFAULT_COS_GLOBAL_SCRAPE_INTERVAL = "60s"` constant and include it as `"timeInterval"` in the dict returned by `_build_grafana_source_extra_fields()`.

- **`coordinator/tests/unit/test_grafana_source_extra_fields.py`** (new): Add test covering both the end-to-end relation data flow:
  - `test_grafana_source_relation_extra_fields` — verifies the `extra_fields` dict     (including `timeInterval`) lands in the grafana-source relation app data bag.
