### PR TITLE
fix: move icon to parts!

### DIFF
--- a/worker/charmcraft.yaml
+++ b/worker/charmcraft.yaml
@@ -41,6 +41,11 @@ parts:
     plugin: uv
     build-packages: [git]
     build-snaps: [astral-uv]
+  icon:
+    plugin: dump
+    source: .
+    stage:
+      - icon.svg
 
 # The Mimir coordinator has a hardcoded dependency on the mount location,
 # and it relies on this path to generate the configuration.
@@ -53,11 +58,6 @@ containers:
         location: /data
       - storage: recovery-data
         location: /recovery-data
-  icon:
-    plugin: dump
-    source: .
-    stage:
-      - icon.svg
 
 resources:
   mimir-image:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR [fixes the icon for the worker](https://github.com/canonical/mimir-operators/pull/122/changes) which was placed under `containers` instead of `parts`