### PR TITLE
fix: use ClusterIP service as the Grafana datasource URL

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -237,10 +237,8 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         if hasattr(self, "coordinator") and self.coordinator.nginx.are_certificates_on_disk:
             scheme = "https"
             port = NGINX_TLS_PORT
-        # The hostname we need is the ClusterIP service hostname, NOT the headless service hostname.
-        # If we use the headless service hostname, Grafana will fail to query Mimir as a datasource when there is no ingress AND internal TLS is used.
-        # See https://github.com/canonical/mimir-operators/issues/232 for details.
-        # The coordinator's app_hostname method will return the correct hostname for the service, which is <app-name>.<juju-model>.svc.cluster.local
+
+        # We use the ClusterIP service, not the headless service to avoid https://github.com/canonical/mimir-operators/issues/232.
         service_hostname = self.coordinator.app_hostname(
             self.hostname, self.app.name, self.model.name
         )

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -237,8 +237,13 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         if hasattr(self, "coordinator") and self.coordinator.nginx.are_certificates_on_disk:
             scheme = "https"
             port = NGINX_TLS_PORT
-        # hostname is e.g. "mimir-0.mimir-coordinator-endpoints..."; strip unit prefix for service URL
-        service_hostname = self.hostname.split(".", 1)[-1]
+        # The hostname we need is the ClusterIP service hostname, NOT the headless service hostname.
+        # If we use the headless service hostname, Grafana will fail to query Mimir as a datasource when there is no ingress AND internal TLS is used.
+        # See https://github.com/canonical/mimir-operators/issues/232 for details.
+        # The coordinator's app_hostname method will return the correct hostname for the service, which is <app-name>.<juju-model>.svc.cluster.local
+        service_hostname = self.coordinator.app_hostname(
+            self.hostname, self.app.name, self.model.name
+        )
         return f"{scheme}://{service_hostname}:{port}"
 
     @property


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #232.

## Solution
<!-- A summary of the solution addressing the above issue -->
I think while both options proposed in the issue will work, fundamentally, the first proposed option of using the ClusterIP service is more correct. The reason I observed this issue is because the Grafana source relation was not behaving as expected. By definition, the Grafana source relation is an app-level concern, not a unit-level concern. As such, Grafana should use an address that is designed for app-level communication, not a headless service. The ClusterIP service is meant to be the app-level communication service, while the headless service is really meant for direct comms with an individual pod and to be something for a reliable pod FQDN to be hooked to.

We certainly can have the Grafana source relation use the headless service to query Grafana, but fundamentally, that's where we should instead be using the ClusterIP service. That's why I think the CW code is probably correct as it, it only includes the individual pod FQDNs (based on the headless service) in the SAN, to be used for workload-metrics-scraping purposes.

Final verdict from my POV is that this should be fixed downstream in Mimir and Loki, without bothering the CW code yet. We should ensure Grafana uses the ClusterIP service rather than include the headless service in the SAN.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy the bundle below. It's meant to simulate a scenario where Mimir has no ingress but is signed by SSC.
```yaml
bundle: kubernetes
applications:
  avalanche:
    charm: avalanche-k8s
    channel: dev/edge
    revision: 69
    base: ubuntu@26.04/stable
    resources:
      avalanche-image: 21
    scale: 1
    constraints: arch=amd64
    trust: true
  grafana:
    charm: grafana-k8s
    channel: dev/edge
    revision: 190
    base: ubuntu@26.04/stable
    resources:
      grafana-image: 79
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  mimir:
    charm: mimir-coordinator-k8s
    channel: dev/edge
    revision: 110
    base: ubuntu@26.04/stable
    resources:
      nginx-image: 16
      nginx-prometheus-exporter-image: 5
    scale: 1
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=mimir,anti-pod.topology-key=kubernetes.io/hostname
    trust: true
  mimir-backend:
    charm: mimir-worker-k8s
    channel: dev/edge
    revision: 99
    base: ubuntu@26.04/stable
    resources:
      mimir-image: 18
    scale: 1
    options:
      role-backend: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=mimir-backend,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  mimir-read:
    charm: mimir-worker-k8s
    channel: dev/edge
    revision: 99
    base: ubuntu@26.04/stable
    resources:
      mimir-image: 18
    scale: 1
    options:
      role-read: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=mimir-read,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  mimir-s3-integrator:
    charm: s3-integrator
    channel: 2/stable
    revision: 544
    scale: 1
    options:
      bucket: mimir
      credentials: secret:6mpshttqr2isl4eu41n0
      endpoint: http://10.181.160.101:8080
    constraints: arch=amd64
    trust: true
  mimir-write:
    charm: mimir-worker-k8s
    channel: dev/edge
    revision: 99
    base: ubuntu@26.04/stable
    resources:
      mimir-image: 18
    scale: 1
    options:
      role-write: true
    constraints: arch=amd64 tags=anti-pod.app.kubernetes.io/name=mimir-write,anti-pod.topology-key=kubernetes.io/hostname
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  opentelemetry-collector:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 218
    base: ubuntu@26.04/stable
    resources:
      opentelemetry-collector-image: 11
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  ssc:
    charm: self-signed-certificates
    channel: 1/stable
    revision: 586
    scale: 1
    constraints: arch=amd64
  traefik:
    charm: traefik-k8s
    channel: latest/edge
    revision: 377
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 172
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - mimir:s3
  - mimir-s3-integrator:s3-credentials
- - opentelemetry-collector:receive-ca-cert
  - ssc:send-ca-cert
- - avalanche:metrics-endpoint
  - opentelemetry-collector:metrics-endpoint
- - grafana:receive-ca-cert
  - ssc:send-ca-cert
- - ssc:certificates
  - traefik:certificates
- - grafana:ingress
  - traefik:ingress
- - mimir:mimir-cluster
  - mimir-read:mimir-cluster
- - mimir:receive-remote-write
  - opentelemetry-collector:send-remote-write
- - mimir:mimir-cluster
  - mimir-write:mimir-cluster
- - mimir:certificates
  - ssc:certificates
- - mimir:mimir-cluster
  - mimir-backend:mimir-cluster
- - grafana:grafana-source
  - mimir:grafana-source
- - opentelemetry-collector:metrics-endpoint
  - mimir:self-metrics-endpoint
- - grafana:grafana-dashboard
  - mimir:grafana-dashboards-provider
--- # overlay.yaml
applications:
  ssc:
    offers:
      certificates:
        endpoints:
        - certificates
        acl:
          admin: admin
      send-ca-cert:
        endpoints:
        - send-ca-cert
        acl:
          admin: admin

```
If you go to the Grafana dashboards page, you'll see errors like this
<img width="1128" height="384" alt="image" src="https://github.com/user-attachments/assets/c509157f-45e8-4d82-80c3-bf23463f4654" />

Now pack the charm and refresh Mimir.
Now, the dashboards will work.
<img width="2127" height="923" alt="image" src="https://github.com/user-attachments/assets/23e91f70-aab1-4db2-8671-42266d112913" />


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
Must be applied for Loki coordinator and has to be backported to track 3 for both. 