### PR TITLE
fix (track 2.17): use ClusterIP service as the Grafana datasource URL (#238)

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -237,8 +237,11 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         if hasattr(self, "coordinator") and self.coordinator.nginx.are_certificates_on_disk:
             scheme = "https"
             port = NGINX_TLS_PORT
-        # hostname is e.g. "mimir-0.mimir-coordinator-endpoints..."; strip unit prefix for service URL
-        service_hostname = self.hostname.split(".", 1)[-1]
+
+        # We use the ClusterIP service, not the headless service to avoid https://github.com/canonical/mimir-operators/issues/232.
+        service_hostname = self.coordinator.app_hostname(
+            self.hostname, self.app.name, self.model.name
+        )
         return f"{scheme}://{service_hostname}:{port}"
 
     @property


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Backport of #238.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
