### PR TITLE
fix: update ingress rel data on reconcile

### DIFF
--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -167,6 +167,9 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         self.framework.observe(self.ingress.on.ready, self._on_ingress_ready)
         self.framework.observe(self.ingress.on.revoked, self._on_ingress_revoked)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
+        self.framework.observe(
+            self.on.certificates_relation_broken, self._on_certificates_changed
+        )
 
     ##########################
     # === EVENT HANDLERS === #
@@ -186,6 +189,12 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         logger.info("Ingress for app revoked")
         if self.coordinator.can_handle_events:
             self._reconcile()
+
+    def _on_certificates_changed(self, _) -> None:
+        """Certificates relation changed: reconcile ingress scheme/port."""
+        if self.coordinator.can_handle_events:
+            self._reconcile()
+
     ######################
     # === PROPERTIES === #
     ######################
@@ -513,6 +522,12 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         # Open necessary service ports. needed for telemetry proxying.
         nginx_port = NGINX_TLS_PORT if self.coordinator.tls_available else NGINX_PORT
         self.unit.set_ports(nginx_port)
+
+        # Re-publish ingress requirements so scheme/port reflect current TLS state.
+        # The scheme lambda is evaluated at publish time, so after the Coordinator's reconcile
+        # has synced certificates, this will correctly publish http or https.
+        if port := urlparse(self.internal_url).port:
+            self.ingress.provide_ingress_requirements(port=port)
 
 
     def _build_grafana_source_extra_fields(self) -> Dict[str, Any]:

--- a/coordinator/tests/unit/helpers.py
+++ b/coordinator/tests/unit/helpers.py
@@ -3,7 +3,7 @@ import yaml
 
 def get_relation_data(relations, endpoint, key):
     """Retrieve the value for a given key from the local_app_data of a relation with the specified endpoint."""
-    relevant = [r.local_app_data[key] for r in relations if r.endpoint == endpoint]
+    relevant = [r.local_app_data.get(key) for r in relations if r.endpoint == endpoint]
     assert len(relevant) < 2, "This helper currently assumes only one relation."
     return relevant[0] if relevant else None
 

--- a/coordinator/tests/unit/test_tls.py
+++ b/coordinator/tests/unit/test_tls.py
@@ -18,7 +18,7 @@ def test_ingress_tls(
     nginx_container,
     nginx_prometheus_exporter_container,
 ):
-    # GIVEN Loki is related over the ingress and certificates endpoints
+    # GIVEN Mimir is related over the ingress and certificates endpoints
     ingress = Relation("ingress")
     certificates = Relation("certificates")
 
@@ -42,7 +42,7 @@ def test_ingress_tls(
         # THEN there are no certificates on disk
         assert not charm.coordinator.nginx.are_certificates_on_disk
 
-        # AND Loki publishes its Nginx non-TLS port in the ingress databag
+        # AND Mimir publishes its Nginx non-TLS port in the ingress databag
         assert get_relation_data(state_out.relations, "ingress", "port") == str(NGINX_PORT)
 
     # AND WHEN TLS is enabled
@@ -50,7 +50,7 @@ def test_ingress_tls(
         # AND the ingress databag is updated
         state_out = context.run(context.on.relation_changed(ingress), state_in)
 
-        # THEN Loki publishes its Nginx TLS port in the ingress databag
+        # THEN Mimir publishes its Nginx TLS port in the ingress databag
         assert get_relation_data(state_out.relations, "ingress", "scheme") == '"https"'
         assert get_relation_data(state_out.relations, "ingress", "port") == str(NGINX_TLS_PORT)
 
@@ -101,3 +101,44 @@ def test_rules_sync_command_adds_tls_ca_path_over_https(
 
     # THEN mimirtool is told to verify against Mimir's CA bundle (otelcol-operator#328)
     assert any(arg.startswith("--tls-ca-path=") for arg in command)
+
+def test_ingress_scheme_switches_to_http_when_certificates_relation_removed(
+    context,
+    s3,
+    all_worker,
+    nginx_container,
+    nginx_prometheus_exporter_container,
+):
+    ingress = Relation("ingress")
+    certificates = Relation("certificates")
+
+    state = State(
+        relations=[
+            s3,
+            all_worker,
+            ingress,
+            certificates,
+        ],
+        containers=[nginx_container, nginx_prometheus_exporter_container],
+        leader=True,
+    )
+
+    # GIVEN TLS is available
+    with patch.object(Nginx, "are_certificates_on_disk", new=True):
+        state = context.run(context.on.relation_joined(ingress), state)
+
+        # THEN ingress databag shows https scheme and TLS port
+        assert get_relation_data(state.relations, "ingress", "scheme") == '"https"'
+        assert get_relation_data(state.relations, "ingress", "port") == str(NGINX_TLS_PORT)
+
+    # WHEN the certificates relation is removed
+    state = context.run(
+        context.on.relation_broken(state.get_relation(certificates.id)),
+        state,
+    )
+
+    # THEN the ingress databag is updated to the non-TLS port
+    assert get_relation_data(state.relations, "ingress", "port") == str(NGINX_PORT)
+    # AND scheme is either "http" or absent (defaults to "http" when excluded from dump)
+    scheme = get_relation_data(state.relations, "ingress", "scheme")
+    assert scheme is None or scheme == '"http"', f"Expected http or absent, got {scheme}"

--- a/coordinator/tests/unit/test_tls.py
+++ b/coordinator/tests/unit/test_tls.py
@@ -42,7 +42,7 @@ def test_ingress_tls(
         # THEN there are no certificates on disk
         assert not charm.coordinator.nginx.are_certificates_on_disk
 
-        # AND Mimir publishes its Nginx non-TLS port in the ingress databag
+        # AND Mimir publishes its Nginx port in the ingress databag
         assert get_relation_data(state_out.relations, "ingress", "port") == str(NGINX_PORT)
 
     # AND WHEN TLS is enabled
@@ -129,7 +129,7 @@ def test_ingress_scheme_switches_to_http_when_certificates_relation_removed(
 
         # THEN ingress databag shows https scheme and TLS port
         assert get_relation_data(state.relations, "ingress", "scheme") == '"https"'
-        assert get_relation_data(state.relations, "ingress", "port") == str(NGINX_TLS_PORT)
+        assert get_relation_data(state.relations, "ingress", "port") == str(NGINX_PORT)
 
     # WHEN the certificates relation is removed
     state = context.run(
@@ -137,7 +137,7 @@ def test_ingress_scheme_switches_to_http_when_certificates_relation_removed(
         state,
     )
 
-    # THEN the ingress databag is updated to the non-TLS port
+    # THEN the ingress databag is still the same as before
     assert get_relation_data(state.relations, "ingress", "port") == str(NGINX_PORT)
     # AND scheme is either "http" or absent (defaults to "http" when excluded from dump)
     scheme = get_relation_data(state.relations, "ingress", "scheme")


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #252.
Similar to https://github.com/canonical/loki-operators/pull/247

This change also relies on fixes in #438.
## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
### Before
To observe the before behaviour, deploy the following bundle which simulates the "full TLS + ingress" scenario.
```yaml
bundle: kubernetes
applications:
  avalanche:
    charm: avalanche-k8s
    channel: dev/edge
    revision: 69
    base: ubuntu@26.04/stable
    resources:
      avalanche-image: 21
    scale: 1
    constraints: arch=amd64
    trust: true
  graf:
    charm: grafana-k8s
    channel: dev/edge
    revision: 190
    base: ubuntu@26.04/stable
    resources:
      grafana-image: 79
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  mimir:
    charm: mimir-coordinator-k8s
    channel: dev/edge
    revision: 110
    base: ubuntu@26.04/stable
    resources:
      nginx-image: 16
      nginx-prometheus-exporter-image: 5
    scale: 1
    constraints: arch=amd64
    trust: true
  mimir-all:
    charm: mimir-worker-k8s
    channel: dev/edge
    revision: 99
    base: ubuntu@26.04/stable
    resources:
      mimir-image: 18
    scale: 1
    options:
      role-all: true
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  otelcol:
    charm: opentelemetry-collector-k8s
    channel: dev/edge
    revision: 221
    base: ubuntu@26.04/stable
    resources:
      opentelemetry-collector-image: 11
    scale: 1
    constraints: arch=amd64
    storage:
      persisted: kubernetes,1,1024M
    trust: true
  ssc:
    charm: self-signed-certificates
    channel: 1/stable
    revision: 586
    scale: 1
    constraints: arch=amd64
  swfs:
    charm: seaweedfs-k8s
    channel: latest/edge
    revision: 9
    resources:
      seaweedfs-image: 2
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  traefik:
    charm: traefik-k8s
    channel: latest/edge
    revision: 393
    base: ubuntu@20.04/stable
    resources:
      traefik-image: 173
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - mimir:mimir-cluster
  - mimir-all:mimir-cluster
- - mimir:s3
  - swfs:s3-credentials
- - traefik:ingress
  - mimir:ingress
- - avalanche:metrics-endpoint
  - otelcol:metrics-endpoint
- - mimir:receive-remote-write
  - otelcol:send-remote-write
- - traefik:certificates
  - ssc:certificates
- - graf:grafana-source
  - mimir:grafana-source
- - graf:ingress
  - traefik:ingress
- - otelcol:receive-ca-cert
  - ssc:send-ca-cert
- - mimir:certificates
  - ssc:certificates
- - graf:receive-ca-cert
  - ssc:send-ca-cert

```

Notice that initially, Mimir writes the scheme `https` to relation data with Traefik, which is correct and expected.
```yaml
  - relation-id: 6
    endpoint: ingress
    related-endpoint: ingress
    application-data:
      is_port_open: "true"
      model: '"test"'
      name: '"mimir"'
      port: "443"
      scheme: '"https"'
      strip-prefix: "true"
    related-units:
      mimir/0:
        in-scope: true
        data:
          host: '"mimir-0.mimir-endpoints.test.svc.cluster.local"'
          ip: '"10.1.0.129"'
```

Now, to move to the "external TLS + ingress" scenario, remove the relation between Mimir and SSC.

Notice that Traefik still thinks it needs to speak HTTPS to Mimir and no changes are made to relation data.
```yaml
  - relation-id: 6
    endpoint: ingress
    related-endpoint: ingress
    application-data:
      is_port_open: "true"
      model: '"test"'
      name: '"mimir"'
      port: "443"
      scheme: '"https"'
      strip-prefix: "true"
    related-units:
      mimir/0:
        in-scope: true
        data:
          host: '"mimir-0.mimir-endpoints.test.svc.cluster.local"'
          ip: '"10.1.0.129"'

```
Otelcol will fail to remote write to Mimir, as can be seen from the Pebble logs:
```
2026-08-03T18:01:49.610Z [otelcol] 2026-08-03T18:01:49.610Z	error	internal/queue_sender.go:51	Exporting failed. Dropping data.	{"resource": {"juju_application": "otelcol", "juju_charm": "opentelemetry-collector-k8s", "juju_model": "test", "juju_model_uuid": "9e981b05-0dee-460b-84b8-c7cc11193232", "juju_unit": "otelcol/0", "loki.format": "logfmt", "loki.resource.labels": "juju_application, juju_charm, juju_model, juju_model_uuid, juju_unit", "service.instance.id": "otelcol/0", "service.name": "otelcol-internal", "service.version": "0.130.1"}, "otelcol.component.id": "prometheusremotewrite/send-remote-write/0", "otelcol.component.kind": "exporter", "otelcol.signal": "metrics", "error": "Permanent error: Permanent error: context deadline exceeded; Permanent error: Permanent error: context deadline exceeded", "errorCauses": [{"error": "Permanent error: Permanent error: context deadline exceeded"}, {"error": "Permanent error: Permanent error: context deadline exceeded"}], "dropped_items": 5005}
```
This is because Otelcol goes through Traefik and Traefik tries to speak HTTPS to an HTTP endpoint.
```
2026-08-03T18:07:23.401Z [otelcol] 2026-08-03T18:07:23.400Z	error	internal/queue_sender.go:51	Exporting failed. Dropping data.	{"resource": {"juju_application": "otelcol", "juju_charm": "opentelemetry-collector-k8s", "juju_model": "test", "juju_model_uuid": "9e981b05-0dee-460b-84b8-c7cc11193232", "juju_unit": "otelcol/0", "loki.format": "logfmt", "loki.resource.labels": "juju_application, juju_charm, juju_model, juju_model_uuid, juju_unit", "service.instance.id": "otelcol/0", "service.name": "otelcol-internal", "service.version": "0.130.1"}, "otelcol.component.id": "prometheusremotewrite/send-remote-write/0", "otelcol.component.kind": "exporter", "otelcol.signal": "metrics", "error": "Permanent error: Permanent error: context deadline exceeded", "dropped_items": 33}
```
Traefik shows the following errors:
```
2026-08-03T18:08:22.964Z [traefik] time="2026-08-03T18:08:22Z" level=error msg="'500 Internal Server Error' caused by: tls: first record does not look like a TLS handshake"
```

Attempting to curl the Mimir endpoint from inside the Traefik container shows:
```
curl https://mimir-0.mimir-endpoints.test.svc.cluster.local:443
curl: (35) TLS connect error: error:0A00010B:SSL routines::wrong version number

```
### After
First, re-relate Mimir and SSC. Refresh the Mimir coordinator charm with the changes in this PR. This time, notice that the relation data with Traefik is updated to correctly omit a scheme of HTTPS (the default is HTTP).
```yaml
  - relation-id: 6
    endpoint: ingress
    related-endpoint: ingress
    application-data:
      is_port_open: "true"
      model: '"test"'
      name: '"mimir"'
      port: "8080"
      strip-prefix: "true"
    related-units:
      mimir/0:
        in-scope: true
        data:
          host: '"mimir-0.mimir-endpoints.test.svc.cluster.local"'
          ip: '"10.1.0.38"'

```
Traefik's dynamic config also correctly expects Mimir to serve HTTP.
```yaml
cat /opt/traefik/juju/juju_ingress_ingress_6_mimir.yaml 
http:
  middlewares:
    juju-sidecar-noprefix-test-mimir:
      stripPrefix:
        forceSlash: false
        prefixes:
        - /test-mimir
  routers:
    juju-test-mimir-router:
      entryPoints:
      - web
      middlewares:
      - juju-sidecar-noprefix-test-mimir
      rule: PathPrefix(`/test-mimir`)
      service: juju-test-mimir-service
    juju-test-mimir-router-tls:
      entryPoints:
      - websecure
      middlewares:
      - juju-sidecar-noprefix-test-mimir
      rule: PathPrefix(`/test-mimir`)
      service: juju-test-mimir-service
      tls: {}
  services:
    juju-test-mimir-service:
      loadBalancer:
        servers:
        - url: http://mimir-0.mimir-endpoints.test.svc.cluster.local:8080

```
## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
