### PR TITLE
feat: remove alert rules helper from coordinator and use lib's public method

### DIFF
--- a/coordinator/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/coordinator/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -184,7 +184,7 @@ import platform
 import re
 import subprocess
 import tempfile
-import uuid
+
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 import yaml
@@ -217,7 +217,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 50
+LIBPATCH = 51
 
 PYDEPS = ["cosl >= 0.0.50"]
 
@@ -390,6 +390,13 @@ REACTIVE_CONVERTER = {  # type: ignore
     "type": "query",
     "useTags": False,
 }
+
+
+def _data_hash(data: Any) -> str:
+    """Deterministic hash of a template dict for use as a stable relation data key."""
+    return hashlib.shake_128(
+        json.dumps(data, sort_keys=True).encode()
+    ).digest(8).hex()
 
 
 class RelationNotFoundError(Exception):
@@ -1366,10 +1373,12 @@ class GrafanaDashboardProvider(Object):
             return  # No change in templates, don't update the databag
 
         # It's completely ridiculous to add a UUID, but if we don't have some
-        # pseudo-random value, this never makes it across 'juju set-state'
+        # pseudo-random value, this never makes it across 'juju set-state'.
+        # Use a deterministic hash of the templates so the value is stable when
+        # templates haven't changed, avoiding spurious relation-changed events.
         stored_data = {
             "templates": new_templates,
-            "uuid": str(uuid.uuid4()),
+            "uuid": _data_hash(new_templates),
         }
 
         relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
@@ -1733,7 +1742,7 @@ class GrafanaDashboardConsumer(Object):
         if not peers or not peers.data:
             logger.info("set_peer_data: no peer relation. Is the charm being installed/removed?")
             return
-        peers.data[self._charm.app][key] = json.dumps(data)  # type: ignore[attr-defined]
+        peers.data[self._charm.app][key] = json.dumps(data, sort_keys=True)  # type: ignore[attr-defined]
 
     def get_peer_data(self, key: str) -> Any:
         """Retrieve information from the peer data bucket instead of `StoredState`."""
@@ -1864,10 +1873,12 @@ class GrafanaDashboardAggregator(Object):
                 if new_templates == existing_templates:
                     continue  # No change in templates, don't update the databag
 
-                # It's still ridiculous to add a UUID here, but needed
+                # It's still ridiculous to add a UUID here, but needed.
+                # Use a deterministic hash of the templates so the value is stable when
+                # templates haven't changed, avoiding spurious relation-changed events.
                 stored_data = {
                     "templates": new_templates,
-                    "uuid": str(uuid.uuid4()),
+                    "uuid": _data_hash(new_templates),
                 }
                 grafana_relation.data[self._charm.app]["dashboards"] = json.dumps(stored_data)
 
@@ -1883,9 +1894,10 @@ class GrafanaDashboardAggregator(Object):
         for id in app_ids:
             del self._stored.dashboard_templates[id]  # type: ignore
 
+        remaining_templates = type_convert_stored(self._stored.dashboard_templates)  # pyright: ignore
         stored_data = {
-            "templates": type_convert_stored(self._stored.dashboard_templates),  # pyright: ignore
-            "uuid": str(uuid.uuid4()),
+            "templates": remaining_templates,
+            "uuid": _data_hash(remaining_templates),
         }
 
         if self._charm.unit.is_leader():
@@ -2130,11 +2142,11 @@ class CosTool:
             #       - alert: OtherAlert
             #         expr: up
             transformed_rules = {"groups": []}  # type: ignore
-            for rule in rules["groups"]:
-                transformed = {"name": str(uuid.uuid4()), "rules": [rule]}
+            for i, rule in enumerate(rules["groups"]):
+                transformed = {"name": f"group_{i}", "rules": [rule]}
                 transformed_rules["groups"].append(transformed)
 
-            rule_path.write_text(yaml.dump(transformed_rules))
+            rule_path.write_text(yaml.safe_dump(transformed_rules, sort_keys=True)) # databag-order: ignore
 
             args = [str(self.path), "validate", str(rule_path)]
             # noinspection PyBroadException

--- a/coordinator/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/coordinator/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 62
+LIBPATCH = 65
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -1055,11 +1055,16 @@ class MetricsEndpointConsumer(Object):
                 try:
                     _validate_scrape_jobs(static_scrape_jobs)
                 except subprocess.CalledProcessError as e:
+                    logger.error(f"Invalid scrape job file: {e}")
                     if self._charm.unit.is_leader():
                         data = json.loads(relation.data[self._charm.app].get("event", "{}"))
                         data["scrape_job_errors"] = str(e)
                         relation.data[self._charm.app]["event"] = json.dumps(data)
                 else:
+                    if self._charm.unit.is_leader():
+                        data = json.loads(relation.data[self._charm.app].get("event", "{}"))
+                        data.pop("scrape_job_errors", None)
+                        relation.data[self._charm.app]["event"] = json.dumps(data)
                     scrape_jobs.extend(static_scrape_jobs)
 
         scrape_jobs = _dedupe_job_names(scrape_jobs)
@@ -1357,6 +1362,65 @@ class MetricsEndpointConsumer(Object):
             parts = [target, "80"]
 
         return parts
+
+    def has_invalid_scrape_jobs(self) -> bool:
+        """Check whether any relation reported invalid scrape jobs.
+
+        Validation errors, written to relation app data by this consumer
+        (see :meth:`jobs`), are read back to determine whether the relationship
+        currently carries an invalid scrape job.
+
+        Returns:
+            True if any related metrics provider reported scrape job validation
+            errors, False otherwise.
+        """
+        return self._has_relation_error("scrape_job_errors", "Scrape job validation error")
+
+    def has_invalid_alert_rules(self) -> bool:
+        """Check whether any relation reported invalid alert rules.
+
+        Validation errors, written to relation app data by this consumer
+        (see :attr:`alerts`), are read back to determine whether the relationship
+        currently carries invalid alert rules.
+
+        Returns:
+            True if any related metrics provider reported alert rule validation
+            errors, False otherwise.
+        """
+        return self._has_relation_error("errors", "Alert rule validation error")
+
+    def _has_relation_error(self, error_key: str, error_label: str) -> bool:
+        """Check whether any relation reported the given validation error.
+
+        Args:
+            error_key: the relation app data key that holds the validation error,
+                i.e. "scrape_job_errors" or "errors".
+            error_label: a human readable description of the validation error
+                type, used for logging, e.g. "Scrape job validation error".
+
+        Returns:
+            True if any related metrics provider reported the validation error,
+            False otherwise.
+        """
+        if not self._charm.unit.is_leader():
+            return False
+
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            app_data = relation.data.get(self._charm.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if error_msg := event_data.get(error_key):
+                logger.error("%s on relation %s: %s", error_label, relation.id, error_msg)
+                return True
+
+        return False
 
 
 def _validate_scrape_jobs(jobs: list) -> bool:

--- a/coordinator/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/coordinator/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -44,7 +44,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 18
 
 PYDEPS = ["cosl"]
 
@@ -972,4 +972,50 @@ class PrometheusRemoteWriteProvider(Object):
 
         rules["groups"] = modified_groups
         return rules
+
+    def has_invalid_alert_rules(self) -> bool:
+        """Check whether any relation reported invalid alert rules.
+
+        Validation errors, written to relation app data by the :attr:`alerts`
+        property, are read back to determine whether the relation currently
+        carries an invalid set of alert rules.
+
+        Returns:
+            True if any related consumer reported alert rule validation errors,
+            False otherwise.
+        """
+        return self._has_relation_error("errors", "Alert rule validation error")
+
+    def _has_relation_error(self, error_key: str, error_label: str) -> bool:
+        """Check whether any relation reported the given validation error.
+
+        Args:
+            error_key: the relation app data key that holds the validation error,
+                i.e. "errors".
+            error_label: a human readable description of the validation error
+                type, used for logging, e.g. "Alert rule validation error".
+
+        Returns:
+            True if any related consumer reported the validation error,
+            False otherwise.
+        """
+        if not self._charm.unit.is_leader():
+            return False
+
+        for relation in self._charm.model.relations.get(self._relation_name, []):
+            app_data = relation.data.get(self._charm.app)
+            if not app_data:
+                continue
+
+            event_raw = app_data.get("event", "{}")
+            try:
+                event_data = json.loads(event_raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if error_msg := event_data.get(error_key):
+                logger.error("%s on relation %s: %s", error_label, relation.id, error_msg)
+                return True
+
+        return False
 

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -11,7 +11,6 @@ https://discourse.charmhub.io/t/4208
 """
 
 import hashlib
-import json
 import logging
 import socket
 from typing import Any, Dict, List, Optional, Union, cast
@@ -31,9 +30,6 @@ from charms.mimir_coordinator_k8s.v0.prometheus_api import (
     DEFAULT_RELATION_NAME as PROMETHEUS_API_RELATION_NAME,
 )
 from charms.mimir_coordinator_k8s.v0.prometheus_api import PrometheusApiProvider
-from charms.prometheus_k8s.v1.prometheus_remote_write import (
-    DEFAULT_RELATION_NAME as REMOTE_WRITE_RELATION_NAME,
-)
 from charms.prometheus_k8s.v1.prometheus_remote_write import PrometheusRemoteWriteProvider
 from charms.traefik_k8s.v2.ingress import IngressPerAppReadyEvent, IngressPerAppRequirer
 from coordinated_workers.coordinator import Coordinator
@@ -469,33 +465,8 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
         if not is_valid_timespec(self.retention_period):
             logger.info(f"Suspending data deletion due to invalid option set in config: {self.retention_period}. To resume data deletion, please reset value to a valid option.")
             event.add_status(BlockedStatus(f"Invalid config option (see debug-log): retention_period={self.retention_period}"))
-        if self._has_alert_rule_errors():
+        if self.remote_write_provider.has_invalid_alert_rules():
             event.add_status(BlockedStatus("Invalid alert rules. See debug-log"))
-
-    def _has_alert_rule_errors(self) -> bool:
-        """Check if any remote-write relation reported validation errors."""
-        if not self.unit.is_leader():
-            return False
-        for relation in self.model.relations.get(REMOTE_WRITE_RELATION_NAME, []):
-            app_data = relation.data.get(self.app)
-            if not app_data:
-                continue
-
-            event_raw = app_data.get("event", "{}")
-            try:
-                event_data = json.loads(event_raw)
-            except (json.JSONDecodeError, TypeError):
-                continue
-
-            if event_data.get("errors"):
-                logger.error(
-                    "Alert rule validation error on relation %s: %s",
-                    relation.id,
-                    event_data["errors"],
-                )
-                return True
-
-        return False
 
     def _reconcile(self):
         # This method contains unconditional update logic, i.e. logic that should be executed


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Based on changes in https://github.com/canonical/prometheus-k8s-operator/pull/851
Makes improvements to https://github.com/canonical/mimir-operators/pull/98.

## Solution
<!-- A summary of the solution addressing the above issue -->
Remove the `_has_alert_rule_errors` helper from the charm and use the public helper `has_invalid_alert_rules` from `prometheus_remote_write`.

This PR also does `charmcraft fetch-lib` to fetch the latest changes in the remote write lib. Some other lib changes have also been pulled.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
https://github.com/canonical/mimir-operators/pull/98 added the unit test `test_alert_rule_filtering`. As long as that utest finished successfully, this change is tested.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
