### PR TITLE
feat: set a default retention period of 15 days

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -217,10 +217,9 @@ config:
         Ref: https://grafana.com/docs/mimir/latest/manage/use-exemplars/store-exemplars/
       type: int
     metrics_retention_period:
-      default: "0"
+      default: "15d"
       description: |
         Sets a global retention period for metrics in Mimir. Supported units: d, w, m, y, h, s, ms or 0 for no limit (disable)
         When this value is set to an invalid value (e.g. "1week"), the charm will be blocked along with a relevant message.
-        To avoid data loss, the retention period will be set to the default of 0 in the worker config, effectively disabling data deletion.
       type: string
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Similar to https://github.com/canonical/loki-operators/pull/401.

## Solution
<!-- A summary of the solution addressing the above issue -->
Similar to [Prometheus](https://github.com/canonical/prometheus-k8s-operator/blob/main/charmcraft.yaml#L206-L212) we'll set the default to 15 days.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
### Before
Deploy the following bundle:
```yaml
bundle: kubernetes
applications:
  mimir:
    charm: mimir-coordinator-k8s
    channel: dev/edge
    revision: 110
    base: ubuntu@26.04/stable
    resources:
      nginx-image: 16
      nginx-prometheus-exporter-image: 5
    scale: 1
    constraints: arch=amd64
    trust: true
  mimir-all:
    charm: mimir-worker-k8s
    channel: dev/edge
    revision: 99
    base: ubuntu@26.04/stable
    resources:
      mimir-image: 18
    scale: 1
    options:
      role-all: true
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  swfs:
    charm: seaweedfs-k8s
    channel: latest/edge
    revision: 9
    resources:
      seaweedfs-image: 2
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
relations:
- - mimir:mimir-cluster
  - mimir-all:mimir-cluster
- - mimir:s3
  - swfs:s3-credentials

```
Initially, retention is configured for infinity:
```
jsshc mimir mimir-all/0 cat /etc/worker/config.yaml | yq '.limits'
compactor_blocks_retention_period: 0
ingestion_burst_size: 2000000
ingestion_rate: 100000
max_global_exemplars_per_user: 0
max_global_series_per_user: 0
ruler_max_rule_groups_per_tenant: 0
ruler_max_rules_per_rule_group: 0
data_dir: /data/data-compactor
```
### After
Refresh the charm with changes in this PR:
Now, by default, retention is only for 15 days.
```
jsshc mimir mimir-all/0 cat /etc/worker/config.yaml | yq '.limits'
compactor_blocks_retention_period: 15d
ingestion_burst_size: 2000000
ingestion_rate: 100000
max_global_exemplars_per_user: 0
max_global_series_per_user: 0
ruler_max_rule_groups_per_tenant: 0
ruler_max_rules_per_rule_group: 0
data_dir: /data/data-compactor

```
## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
