### PR TITLE
feat: `ingestion_rate` config option

### DIFF
--- a/coordinator/charmcraft.yaml
+++ b/coordinator/charmcraft.yaml
@@ -216,6 +216,14 @@ config:
         Otherwise, the value is set to the greater of the setpoint or 100,000.
         Ref: https://grafana.com/docs/mimir/latest/manage/use-exemplars/store-exemplars/
       type: int
+    ingestion_rate:
+      default: 100000
+      description: |
+        Per-tenant ingestion rate limit in samples per second. 0 to disable.
+        Negative values are clamped to 0.
+        The ingestion burst size is automatically set to 20x this value.
+        CLI flag: -distributor.ingestion-rate-limit
+      type: int
     metrics_retention_period:
       default: "15d"
       description: |

--- a/coordinator/src/charm.py
+++ b/coordinator/src/charm.py
@@ -113,6 +113,7 @@ class MimirCoordinatorK8SOperatorCharm(ops.CharmBase):
                 alertmanager_urls=self.alertmanager.get_cluster_info(),
                 max_global_exemplars_per_user=int(self.config["max_global_exemplars_per_user"]),
                 metrics_retention_period=self.retention_period if is_valid_timespec(self.retention_period) else None,
+                ingestion_rate=max(0, int(self.config["ingestion_rate"])),
             ).config,
             worker_ports=lambda _: tuple({8080, 9095}),
             resources_requests=self.get_resource_requests,

--- a/coordinator/src/mimir_config.py
+++ b/coordinator/src/mimir_config.py
@@ -362,6 +362,10 @@ class MimirConfig:
 
         Ref: https://grafana.com/docs/mimir/latest/configure/configuration-parameters/#limits
         """
+        # Per-tenant ingestion rate limit in samples per second. 0 to disable.
+        # CLI flag: -distributor.ingestion-rate-limit
+        ingestion_rate = self._ingestion_rate if self._ingestion_rate is not None else 100_000
+
         limits_config: Dict[str, Any] = {
             # Maximum number of rules per rule group per-tenant. 0 to disable.
             # CLI flag: -ruler.max-rules-per-rule-group
@@ -376,14 +380,12 @@ class MimirConfig:
             # CLI flag: -ingester.max-global-series-per-user
             "max_global_series_per_user": 0,  # default = 150000
 
-            # Per-tenant ingestion rate limit in samples per second.
-            # CLI flag: -distributor.ingestion-rate-limit
-            "ingestion_rate": self._ingestion_rate if self._ingestion_rate is not None else 100_000,
+            "ingestion_rate": ingestion_rate,
 
             # Per-tenant allowed ingestion burst size (in number of samples).
             # Automatically set to 20x the ingestion_rate, matching Mimir's default 20x ratio.
             # CLI flag: -distributor.ingestion-burst-size
-            "ingestion_burst_size": (self._ingestion_rate if self._ingestion_rate is not None else 100_000) * 20,
+            "ingestion_burst_size": ingestion_rate * 20,
         }
 
         # Set the max global exemplars per user based on the value of _max_global_exemplars_per_user

--- a/coordinator/src/mimir_config.py
+++ b/coordinator/src/mimir_config.py
@@ -113,6 +113,7 @@ class MimirConfig:
         root_data_dir: Path = Path("/data"),
         recovery_data_dir: Path = Path("/recovery-data"),
         metrics_retention_period: Optional[str] = None,
+        ingestion_rate: Optional[int] = None,
     ):
         self._alertmanager_urls = alertmanager_urls
         self._root_data_dir = root_data_dir
@@ -120,6 +121,7 @@ class MimirConfig:
         self._max_global_exemplars_per_user = max_global_exemplars_per_user
         self._topology = topology
         self._metrics_retention_period: str = metrics_retention_period or "0"
+        self._ingestion_rate = ingestion_rate
 
     def config(self, coordinator: Coordinator) -> str:
         """Generate shared config file for mimir.
@@ -376,11 +378,12 @@ class MimirConfig:
 
             # Per-tenant ingestion rate limit in samples per second.
             # CLI flag: -distributor.ingestion-rate-limit
-            "ingestion_rate": 100_000,  # default = 10000
+            "ingestion_rate": self._ingestion_rate if self._ingestion_rate is not None else 100_000,
 
             # Per-tenant allowed ingestion burst size (in number of samples).
+            # Automatically set to 20x the ingestion_rate, matching Mimir's default 20x ratio.
             # CLI flag: -distributor.ingestion-burst-size
-            "ingestion_burst_size": 2_000_000,  # default = 200000]
+            "ingestion_burst_size": (self._ingestion_rate if self._ingestion_rate is not None else 100_000) * 20,
         }
 
         # Set the max global exemplars per user based on the value of _max_global_exemplars_per_user

--- a/coordinator/tests/unit/test_mimir_config.py
+++ b/coordinator/tests/unit/test_mimir_config.py
@@ -104,13 +104,10 @@ def test_max_global_exemplars_per_user_logic(mimir_config, max_global_exemplars_
         (0,       0,        0),           # 0 → limit disabled, burst also 0
         (50_000,  50_000,   1_000_000),   # custom value → burst = 20x
         (200_000, 200_000,  4_000_000),   # larger custom value
-        (-1,      0,        0),           # negative → clamped to 0 before passing in
     ],
 )
 def test_ingestion_rate_and_burst_logic(topology, ingestion_rate, expected_rate, expected_burst):
-    # Negative values are clamped to 0 by the caller (charm.py), so we replicate that here
-    clamped = max(0, ingestion_rate) if ingestion_rate is not None else None
-    cfg = MimirConfig(topology=topology, ingestion_rate=clamped)
+    cfg = MimirConfig(topology=topology, ingestion_rate=ingestion_rate)
     limits = cfg._build_limits_config()
     assert limits["ingestion_rate"] == expected_rate
     assert limits["ingestion_burst_size"] == expected_burst

--- a/coordinator/tests/unit/test_mimir_config.py
+++ b/coordinator/tests/unit/test_mimir_config.py
@@ -96,6 +96,26 @@ def test_max_global_exemplars_per_user_logic(mimir_config, max_global_exemplars_
     # Assert that the value for max_global_exemplars_per_user matches the expected value
     assert limits_config["max_global_exemplars_per_user"] == expected_value
 
+
+@pytest.mark.parametrize(
+    "ingestion_rate, expected_rate, expected_burst",
+    [
+        (None,    100_000,  2_000_000),   # None → charm defaults unchanged
+        (0,       0,        0),           # 0 → limit disabled, burst also 0
+        (50_000,  50_000,   1_000_000),   # custom value → burst = 20x
+        (200_000, 200_000,  4_000_000),   # larger custom value
+        (-1,      0,        0),           # negative → clamped to 0 before passing in
+    ],
+)
+def test_ingestion_rate_and_burst_logic(topology, ingestion_rate, expected_rate, expected_burst):
+    # Negative values are clamped to 0 by the caller (charm.py), so we replicate that here
+    clamped = max(0, ingestion_rate) if ingestion_rate is not None else None
+    cfg = MimirConfig(topology=topology, ingestion_rate=clamped)
+    limits = cfg._build_limits_config()
+    assert limits["ingestion_rate"] == expected_rate
+    assert limits["ingestion_burst_size"] == expected_burst
+
+
 def test_build_alertmanager_storage_config(mimir_config):
     alertmanager_storage_config = mimir_config._build_alertmanager_storage_config()
     expected_config = {"filesystem": {"dir": "/recovery-data/data-alertmanager"}}


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #406.

## Solution
<!-- A summary of the solution addressing the above issue -->
1. Adds `ingestion_rate` as a charm config option. Negative values are clamped to 0.
2. The default is 100,000.
3. The `ingestion_burst_size` is always `ingestion_rate` * 20. This is the default behaviour in Mimir, where by default, the `ingestion_burst_size` is 20 times that of `ingestion_rate`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
See [upstream docs](https://grafana.com/docs/mimir/latest/configure/configuration-parameters/#limits).

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy the bundle:
```yaml
bundle: kubernetes
applications:
  mimir:
    charm: mimir-coordinator-k8s
    channel: dev/edge/pr412
    revision: 116
    base: ubuntu@26.04/stable
    resources:
      nginx-image: 16
      nginx-prometheus-exporter-image: 5
    scale: 1
    options:
      ingestion_rate: 1000000
    constraints: arch=amd64
    trust: true
  mimir-all:
    charm: mimir-worker-k8s
    channel: dev/edge
    revision: 104
    base: ubuntu@26.04/stable
    resources:
      mimir-image: 18
    scale: 1
    options:
      role-all: true
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
      recovery-data: kubernetes,1,1024M
    trust: true
  swfs:
    charm: seaweedfs-k8s
    channel: latest/edge
    revision: 9
    resources:
      seaweedfs-image: 2
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
relations:
- - mimir:mimir-cluster
  - mimir-all:mimir-cluster
- - mimir:s3
  - swfs:s3-credentials
```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
